### PR TITLE
Change Params.String() function to use url.Values for serialization

### DIFF
--- a/okta/query/query.go
+++ b/okta/query/query.go
@@ -19,7 +19,6 @@
 package query
 
 import (
-	"encoding/json"
 	"net/url"
 	"strconv"
 )
@@ -189,31 +188,78 @@ func WithOauthTokens(oauthTokens bool) ParamOptions {
 }
 
 func (p *Params) String() string {
-	s, _ := json.Marshal(p)
+	qs := url.Values{}
 
-	m := map[string]interface{}{}
-	qs := ""
-	i := 1
-
-	json.Unmarshal(s, &m)
-
-	for key, value := range m {
-		qs = qs + string(key) + "="
-		switch v := value.(type) {
-		case bool:
-			qs = qs + strconv.FormatBool(v)
-		default:
-			qs = qs + url.QueryEscape(value.(string))
-		}
-		if i < len(m) {
-			qs = qs + "&"
-		}
-		i++
+	if (p.Q != "") {
+		qs.Add(`q`, p.Q)
+	}
+	if (p.After != "") {
+		qs.Add(`after`, p.After)
+	}
+	if (p.Limit != 0) {
+		qs.Add(`limit`, strconv.FormatInt(p.Limit, 10))
+	}
+	if (p.Filter != "") {
+		qs.Add(`filter`, p.Filter)
+	}
+	if (p.Expand != "") {
+		qs.Add(`expand`, p.Expand)
+	}
+	if (p.IncludeNonDeleted != nil) {
+		qs.Add(`includeNonDeleted`, strconv.FormatBool(*p.IncludeNonDeleted))
+	}
+	if (p.Activate != nil) {
+		qs.Add(`activate`, strconv.FormatBool(*p.Activate))
+	}
+	if (p.TargetAid != "") {
+		qs.Add(`targetAid`, p.TargetAid)
+	}
+	if (p.QueryScope != "") {
+		qs.Add(`query_scope`, p.QueryScope)
+	}
+	if (p.RemoveUsers != nil) {
+		qs.Add(`removeUsers`, strconv.FormatBool(*p.RemoveUsers))
+	}
+	if (p.Until != "") {
+		qs.Add(`until`, p.Until)
+	}
+	if (p.Since != "") {
+		qs.Add(`since`, p.Since)
+	}
+	if (p.SortOrder != "") {
+		qs.Add(`sortOrder`, p.SortOrder)
+	}
+	if (p.Format != "") {
+		qs.Add(`format`, p.Format)
+	}
+	if (p.Search != "") {
+		qs.Add(`search`, p.Search)
+	}
+	if (p.Provider != "") {
+		qs.Add(`provider`, p.Provider)
+	}
+	if (p.ShowAll != nil) {
+		qs.Add(`showAll`, strconv.FormatBool(*p.ShowAll))
+	}
+	if (p.SendEmail != nil) {
+		qs.Add(`sendEmail`, strconv.FormatBool(*p.SendEmail))
+	}
+	if (p.UpdatePhone != nil) {
+		qs.Add(`updatePhone`, strconv.FormatBool(*p.UpdatePhone))
+	}
+	if (p.TemplateId != "") {
+		qs.Add(`templateId`, p.TemplateId)
+	}
+	if (p.TempPassword != nil) {
+		qs.Add(`tempPassword`, strconv.FormatBool(*p.TempPassword))
+	}
+	if (p.OauthTokens != nil) {
+		qs.Add(`oauthTokens`, strconv.FormatBool(*p.OauthTokens))
 	}
 
-	if qs != "" {
-		qs = "?" + qs
+	if len(qs) != 0 {
+		return "?" + qs.Encode()
 	}
-	return qs
+	return ""
 }
 

--- a/okta/query/query_test.go
+++ b/okta/query/query_test.go
@@ -1,0 +1,56 @@
+package query
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	p := NewQueryParams()
+	qs := p.String()
+	if qs != "" {
+		t.Fatalf("expected empty string got '%s'", qs)
+	}
+}
+
+func TestInt64(t *testing.T) {
+	p := NewQueryParams(WithLimit(100))
+	qs := p.String()
+	if qs != `?limit=100` {
+		t.Fatalf("expected '?limit=100' got '%s'", qs)
+	}
+}
+
+func TestBool(t *testing.T) {
+	p := NewQueryParams(WithActivate(false))
+	qs := p.String()
+	if qs != `?activate=false` {
+		t.Fatalf("expected '?activate=false' got '%s'", qs)
+	}
+
+	p = NewQueryParams(WithActivate(true))
+	qs = p.String()
+	if qs != `?activate=true` {
+		t.Fatalf("expected '?activate=true' got '%s'", qs)
+	}
+}
+
+func TestString(t *testing.T) {
+	p := NewQueryParams(WithQ(`x`))
+	qs := p.String()
+	if qs != "?q=x" {
+		t.Fatalf("expected '?q=x' got '%s'", qs)
+	}
+
+	// Testing if we are applying URL encoding to a reserved char
+	p = NewQueryParams(WithQ(`x=/`))
+	qs = p.String()
+	if qs != `?q=x%3D%2F` {
+		t.Fatalf(`expected '%s' got '%s'`, `?q=x%3D%2F`, qs)
+	}
+}
+
+func TestMultiple(t *testing.T) {
+	p := NewQueryParams(WithQ(`x`), WithLimit(100), WithActivate(true))
+	qs := p.String()
+	if qs != "?activate=true&limit=100&q=x" {
+		t.Fatalf("expected '?activate=true&limit=100&q=x' got '%s'", qs)
+	}
+}

--- a/openapi/generator/templates/query.go.hbs
+++ b/openapi/generator/templates/query.go.hbs
@@ -3,7 +3,6 @@
 package query
 
 import (
-	"encoding/json"
 	"net/url"
 	"strconv"
 )
@@ -45,31 +44,29 @@ func With{{structProp query.name}}({{query.name}} {{query.type}}) ParamOptions {
 {{/each}}
 
 func (p *Params) String() string {
-	s, _ := json.Marshal(p)
+	qs := url.Values{}
 
-	m := map[string]interface{}{}
-	qs := ""
-	i := 1
-
-	json.Unmarshal(s, &m)
-
-	for key, value := range m {
-		qs = qs + string(key) + "="
-		switch v := value.(type) {
-		case bool:
-			qs = qs + strconv.FormatBool(v)
-		default:
-			qs = qs + url.QueryEscape(value.(string))
-		}
-		if i < len(m) {
-			qs = qs + "&"
-		}
-		i++
+{{#each queryOptions as |query|}}
+	{{#if (eq query.type "bool")}}
+	if (p.{{structProp query.name}} != nil) {
+		qs.Add(`{{query.name}}`, strconv.FormatBool(*p.{{structProp query.name}}))
 	}
-
-	if qs != "" {
-		qs = "?" + qs
+	{{else if (eq query.type "int64")}}
+	if (p.{{structProp query.name}} != 0) {
+		qs.Add(`{{query.name}}`, strconv.FormatInt(p.{{structProp query.name}}, 10))
 	}
-	return qs
+	{{else if (eq query.type "string")}}
+	if (p.{{structProp query.name}} != "") {
+		qs.Add(`{{query.name}}`, p.{{structProp query.name}})
+	}
+	{{else}}
+	{{log "query.go.hbs: unknown type for Params.String()" level="error"}}
+	{{/if}}
+{{/each}}
+
+	if len(qs) != 0 {
+		return "?" + qs.Encode()
+	}
+	return ""
 }
 


### PR DESCRIPTION
The previous version of this marshelled the Params structure to JSON, then
unmarshaled the JSON in order to construct a URL-escaped query params. Now
we directly generate from the template variables a direct encoder to
url.Values.

Fixes https://github.com/okta/okta-sdk-golang/issues/27