### PR TITLE
fix type of ErrorCauses field in the Error struct

### DIFF
--- a/okta/error.go
+++ b/okta/error.go
@@ -17,11 +17,11 @@
 package okta
 
 type Error struct {
-	ErrorCode    string   `json:"errorCode,omitempty"`
-	ErrorSummary string   `json:"errorSummary,omitempty"`
-	ErrorLink    string   `json:"errorLink,omitempty"`
-	ErrorId      string   `json:"errorId,omitempty"`
-	ErrorCauses  []string `json:"errorCauses,omitempty"`
+	ErrorCode    string                   `json:"errorCode,omitempty"`
+	ErrorSummary string                   `json:"errorSummary,omitempty"`
+	ErrorLink    string                   `json:"errorLink,omitempty"`
+	ErrorId      string                   `json:"errorId,omitempty"`
+	ErrorCauses  []map[string]interface{} `json:"errorCauses,omitempty"`
 }
 
 func (e *Error) Error() string {


### PR DESCRIPTION
Updating the `ErrorCauses` field in the `Error` struct in `error.go` to match what's sent from Okta.  Currently the json.Unmarshal sets the `ErrorCauses` field to an empty array.

```
(dlv) print err
error(*github.com/articulate/terraform-provider-okta/vendor/github.com/okta/okta-sdk-golang/okta.Error) *{
	ErrorCode: "E0000001",
	ErrorSummary: "Api validation failed: newUser",
	ErrorLink: "E0000001",
	ErrorId: "oaefaxVj7f-TW6irLILSj0R7g",
	ErrorCauses: []string len: 1, cap: 4, [""],}
```

This update fixes that blank array and surfaces the causes of the error from Okta.

```
(dlv) print err
error(*github.com/articulate/terraform-provider-okta/vendor/github.com/okta/okta-sdk-golang/okta.Error) *{
	ErrorCode: "E0000001",
	ErrorSummary: "Api validation failed: newUser",
	ErrorLink: "E0000001",
	ErrorId: "oae4sQW9qedThmM41VSBaHLgA",
	ErrorCauses: []map[string]interface {} len: 1, cap: 4, [
		[...],
	],}

(dlv) print err.ErrorCauses
[]map[string]interface {} len: 1, cap: 4, [
	[
		"errorSummary": *(*"interface {}")(0xc4203a7168),
	],
]
```