### PR TITLE
Retries and API Rate Limit exponential backoff

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -26,8 +26,9 @@ import (
 )
 
 type Config struct {
-	MaxRetries int32 `yaml:"maxRetries" envconfig:"OKTA_MAX_RETRIES"`
-	Okta       struct {
+	BackoffEnabled bool  `yaml:"withBackoff" envconfig:"OKTA_BACK_OFF_ENABLED"`
+	MaxRetries     int32 `yaml:"maxRetries" envconfig:"OKTA_MAX_RETRIES"`
+	Okta           struct {
 		Client struct {
 			Cache struct {
 				Enabled    bool  `yaml:"enabled" envconfig:"OKTA_CLIENT_CACHE_ENABLED"`
@@ -45,7 +46,6 @@ type Config struct {
 			Token             string `yaml:"token" envconfig:"OKTA_CLIENT_TOKEN"`
 		} `yaml:"client"`
 	} `yaml:"okta"`
-	BackoffEnabled bool `yaml:"withBackoff" envconfig:"OKTA_BACK_OFF_ENABLED"`
 	UserAgentExtra string
 }
 

--- a/okta/config.go
+++ b/okta/config.go
@@ -26,7 +26,8 @@ import (
 )
 
 type Config struct {
-	Okta struct {
+	MaxRetries int32 `yaml:"maxRetries" envconfig:"OKTA_MAX_RETRIES"`
+	Okta       struct {
 		Client struct {
 			Cache struct {
 				Enabled    bool  `yaml:"enabled" envconfig:"OKTA_CLIENT_CACHE_ENABLED"`
@@ -44,6 +45,7 @@ type Config struct {
 			Token             string `yaml:"token" envconfig:"OKTA_CLIENT_TOKEN"`
 		} `yaml:"client"`
 	} `yaml:"okta"`
+	BackoffEnabled bool `yaml:"withBackoff" envconfig:"OKTA_BACK_OFF_ENABLED"`
 	UserAgentExtra string
 }
 
@@ -126,6 +128,16 @@ func (c *Config) WithOrgUrl(url string) *Config {
 
 func (c *Config) WithToken(token string) *Config {
 	c.Okta.Client.Token = token
+	return c
+}
+
+func (c *Config) WithBackoff(backoff bool) *Config {
+	c.BackoffEnabled = backoff
+	return c
+}
+
+func (c *Config) WithRetries(retries int32) *Config {
+	c.MaxRetries = retries
 	return c
 }
 

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -91,7 +91,7 @@ func (re *RequestExecutor) Do(req *http.Request, v interface{}) (*Response, erro
 	inCache := re.cache.Has(cacheKey)
 
 	if !inCache {
-		resp, err := re.doWithRetries(req)
+		resp, err := re.doWithRetries(req, 0)
 
 		if err != nil {
 			return nil, err
@@ -119,14 +119,7 @@ func (re *RequestExecutor) Do(req *http.Request, v interface{}) (*Response, erro
 
 }
 
-func (re *RequestExecutor) doWithRetries(req *http.Request) (*http.Response, error) {
-	retryCount := 0
-	resp, err := re.do(req, retryCount)
-
-	return resp, err
-}
-
-func (re *RequestExecutor) do(req *http.Request, retryCount int) (*http.Response, error) {
+func (re *RequestExecutor) doWithRetries(req *http.Request, retryCount int) (*http.Response, error) {
 	resp, err := re.httpClient.Do(req)
 	maxRetries := int(re.config.MaxRetries)
 	bo := re.config.BackoffEnabled
@@ -137,7 +130,7 @@ func (re *RequestExecutor) do(req *http.Request, retryCount int) (*http.Response
 			Backoff(time.Duration(1<<uint(retryCount)) * time.Second)
 		}
 		retryCount++
-		resp, err = re.do(req, retryCount)
+		resp, err = re.doWithRetries(req, retryCount)
 	}
 
 	return resp, err

--- a/tests/unit/requestExecutor_test.go
+++ b/tests/unit/requestExecutor_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 - Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/okta/okta-sdk-golang/okta"
+	"github.com/okta/okta-sdk-golang/okta/cache"
+)
+
+func doRetryTest(t *testing.T, maxRetries int32, backoffEnabled bool, forceError bool) (*okta.Response, error) {
+	backoffCount := 0
+	okta.Backoff = func(t time.Duration) {
+		backoffCount++
+	}
+	retries := 0
+	var testServer *httptest.Server
+	handler := http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if retries < 3 {
+			if forceError {
+				testServer.CloseClientConnections()
+			} else {
+				res.WriteHeader(http.StatusTooManyRequests)
+			}
+		} else {
+			res.WriteHeader(http.StatusOK)
+			res.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(res).Encode(map[string]string{"success": "yes"})
+		}
+		retries++
+	})
+	testServer = httptest.NewServer(handler)
+	defer testServer.Close()
+	config := &okta.Config{
+		MaxRetries:     maxRetries,
+		BackoffEnabled: backoffEnabled,
+	}
+	var body interface{}
+	re := okta.NewRequestExecutor(&http.Client{}, cache.NoOpCache{}, config)
+	req, err := re.NewRequest("GET", testServer.URL, nil)
+	assert.Nil(t, err)
+	res, err := re.Do(req, &body)
+
+	if backoffEnabled {
+		assert.Equal(t, maxRetries, int32(backoffCount))
+	} else {
+		assert.Equal(t, 0, backoffCount)
+	}
+
+	return res, err
+}
+
+func Test_backoff_with_retry(t *testing.T) {
+	res, err := doRetryTest(t, 3, true, false)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func Test_retries_without_backoff(t *testing.T) {
+	res, err := doRetryTest(t, 3, false, true)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func Test_default_no_backoff_or_retries(t *testing.T) {
+	res, err := doRetryTest(t, 0, false, false)
+	assert.NotNil(t, err)
+	assert.Equal(t, http.StatusTooManyRequests, res.StatusCode)
+}


### PR DESCRIPTION
I didn't get a response on #43 so I thought I would just open a PR. I also serendipitously just found this https://github.com/okta/okta-auth-js/blob/ec20982d4378484609fe64f89278ee1904e69e11/lib/tx.js#L156. That gives me hope this change will be accepted (in some form).

It appears the config.go and requestExecutor.go files are NOT generated and thus I am implementing directly, if this is not the case I am very confused :-D. 