### PR TITLE
Update base applicaitonSettingsApplication

### DIFF
--- a/okta/applicationSettingsApplication.go
+++ b/okta/applicationSettingsApplication.go
@@ -20,8 +20,7 @@ package okta
 
 import ()
 
-type ApplicationSettingsApplication struct {
-}
+type ApplicationSettingsApplication map[string]interface{}
 
 func NewApplicationSettingsApplication() *ApplicationSettingsApplication {
 	return &ApplicationSettingsApplication{}

--- a/openapi/generator/templates/model.go.hbs
+++ b/openapi/generator/templates/model.go.hbs
@@ -24,9 +24,13 @@ type UserFactor interface {
 type {{model.modelName}}Resource resource
 
 {{/if}}
+{{#if (eq model.modelName "ApplicationSettingsApplication")}}
+type {{model.modelName}} map[string]interface{}
+{{else}}
 type {{model.modelName}} struct {
 	{{{buildModelProperties model}}}
 }
+{{/if}}
 {{#if (or ( eq model.tags.[0] "Application" ) ( eq model.tags.[0] "UserFactor") ) }}
 func New{{model.modelName}}() *{{model.modelName}} {
 	return &{{model.modelName}}{


### PR DESCRIPTION
#52 reported that when using some of the application types, it pulls in ApplicaitonSettingsApplication.  Because this was a struct, it could not have values added to it.

Fix inside of the SDK is to make this a map.

A ticket has been added for updating the openapi spec to include applicaitonSettingsApplicaiton items for each type of application, ie, SAML okta/openapi#174

closes #52 