### PR TITLE
Configuration Checks added

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ You'll also need
 Construct a client instance by passing it your Okta domain name and API token:
 
 ```
-config := okta.NewConfig().WithOrgUrl("https://{yourOktaDomain}").WithToken("{apiToken}")
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 ```
 
 Hard-coding the Okta domain and API token works for quick tests, but for real projects you should use a more secure way of storing these values (such as environment variables). This library supports a few different configuration sources, covered in the [configuration reference](#configuration-reference) section.
@@ -76,8 +75,7 @@ myClient := &http.Client{}
 
 myCache := NewCustomCacheDriver()
 
-config := okta.NewConfig().WithOrgUrl("{yourOktaDomain}").WithToken("{apiToken}")
-client := okta.NewClient(config, myClient, myCache)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"), okta.WithHttpClient(myClient), okta.WithCacheManager(myCache))
 ```
 
 
@@ -118,22 +116,19 @@ This library should only be used with the Okta management API. To call the [Auth
 
 ### Get a User
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 user, resp, err := client.User.GetUser(user.Id, nil)
 ```
 
 ### List all Users
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 users, resp, err := client.User.ListUsers()
 ```
 
 ### Filter or search for Users
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 filter := query.NewQueryParams(query.WithFilter("status eq \"ACTIVE\""))
 
@@ -142,8 +137,7 @@ users, resp, err := client.User.ListUsers(filter)
 
 ### Create a User
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -166,8 +160,7 @@ user, resp, err := client.User.CreateUser(*u, nil)
 
 ### Update a User
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 newProfile := *user.Profile
 newProfile["nickName"] = "Batman"
@@ -180,8 +173,7 @@ user, resp, err := client.User.UpdateUser(user.Id, *updatedUser, nil)
 ### Get and set custom attributes
 Custom attributes must first be defined in the Okta profile editor. Then, you can work with custom attributes on a user:
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 user, resp, err := client.User.GetUser(user.Id, nil)
 
 nickName = user.Profile["nickName"]
@@ -190,8 +182,7 @@ nickName = user.Profile["nickName"]
 ### Remove a User
 You must first deactivate the user, and then you can delete the user.
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 resp, err := client.User.DeactivateUser(user.Id, nil)
 
 resp, err := client.User.DeactivateOrDeleteUser(user.Id, nil)
@@ -199,16 +190,14 @@ resp, err := client.User.DeactivateOrDeleteUser(user.Id, nil)
 
 ### List a User's Groups
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 groups, resp, err := client.User.ListUserGroups(user.Id, nil)
 ```
 
 ### Create a Group
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 gp := &okta.GroupProfile{
   Name: "Get Test Group",
@@ -221,24 +210,21 @@ group, resp, err := client.Group.CreateGroup(*g, nil)
 
 ### Add a User to a Group
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 resp, err := client.Group.AddUserToGroup(group.Id, user.Id, nil)
 ```
 
 ### List a User's enrolled Factors
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 allowedFactors, resp, err := client.Factor.ListSupportedFactors(user.Id)
 ```
 
 ### Enroll a User in a new Factor
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 factorProfile := okta.NewSmsFactorProfile()
 factorProfile.PhoneNumber = "5551234567"
@@ -251,16 +237,14 @@ addedFactor, resp, err := client.Factor.AddFactor(user.Id, factor, nil)
 
 ### Activate a Factor
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 factor, resp, err := client.Factor.ActivateFactor(user.Id, factor.Id, nil)
 ```
 
 ### Verify a Factor
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 verifyFactorRequest := okta.VerifyFactorRequest{
   PassCode: "123456"
@@ -270,8 +254,7 @@ verifyFactorResp, resp, err := client.Factor.VerifyFactor(user.Id, factor.Id, ve
 
 ### List all Applications
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 applications, resp, err := client.Application.ListApplications(nil)
 
@@ -288,8 +271,7 @@ for _, a := range applications {
 
 ### Get an Application
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 //Getting a Basic Auth Application
 application, resp, err = client.Application.GetApplication(appId, okta.NewBasicAuthApplication(), nil)
@@ -300,8 +282,7 @@ app := application.(*okta.BasicAuthApplication)
 
 ### Create a SWA Application
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 swaAppSettingsApp := newSwaApplicationSettingsApplication()
 swaAppSettingsApp.ButtonField = "btn-login"
@@ -323,8 +304,7 @@ application, resp, err := client.Application.CreateApplication(swaApp, nil)
 ### Call other API endpoints
 Not every API endpoint is represented by a method in this library. You can call any Okta management API endpoint using this generic syntax:
 ```
-config := okta.NewConfig()
-client := okta.NewClient(config, nil, nil)
+client := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"))
 
 url := "https://golang.oktapreview.com/api/v1/authorizationServers
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/okta/okta-sdk-golang
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=
+github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
 github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY8LyvN8BXNM=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/okta/config.go
+++ b/okta/config.go
@@ -17,15 +17,12 @@
 package okta
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os/user"
+	"net/http"
 
-	"github.com/kelseyhightower/envconfig"
-	yaml "gopkg.in/yaml.v2"
+	"github.com/okta/okta-sdk-golang/okta/cache"
 )
 
-type Config struct {
+type config struct {
 	Okta struct {
 		Client struct {
 			Cache struct {
@@ -43,118 +40,97 @@ type Config struct {
 			OrgUrl            string `yaml:"orgUrl" envconfig:"OKTA_CLIENT_ORGURL"`
 			Token             string `yaml:"token" envconfig:"OKTA_CLIENT_TOKEN"`
 		} `yaml:"client"`
+		Testing struct {
+			DisableHttpsCheck bool `yaml:"disableHttpsCheck" envconfig:"OKTA_TESTING_DISABLE_HTTPS_CHECK"`
+		} `yaml:"testing"`
 	} `yaml:"okta"`
 	UserAgentExtra string
+	HttpClient     http.Client
+	CacheManager   cache.Cache
 }
 
-func NewConfig() *Config {
-	c := Config{}
+type ConfigSetter func(*config)
 
-	c.WithCache(true).
-		WithCacheTtl(300).
-		WithCacheTti(300).
-		WithConnectionTimeout(30).
-		WithUserAgentExtra("")
-
-	c = readConfigFromSystem(c)
-	c = readConfigFromApplication(c)
-	c = readConfigFromEnvironment(c)
-
-	return &c
-}
-
-func (c *Config) ReadConfigFromFile(location string) *Config {
-	yamlConfig, err := ioutil.ReadFile(location)
-
-	if err != nil {
-		return c
+func WithCache(cache bool) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Cache.Enabled = cache
 	}
+}
 
-	conf := Config{}
-	err = yaml.Unmarshal(yamlConfig, &conf)
-	if err != nil {
-		return c
+func WithCacheManager(cacheManager cache.Cache) ConfigSetter {
+	return func(c *config) {
+		c.CacheManager = cacheManager
 	}
-
-	return &conf
 }
 
-func (c *Config) WithCache(cache bool) *Config {
-	c.Okta.Client.Cache.Enabled = cache
-	return c
-}
-
-func (c *Config) WithCacheTtl(i int32) *Config {
-	c.Okta.Client.Cache.DefaultTtl = i
-	return c
-}
-
-func (c *Config) WithCacheTti(i int32) *Config {
-	c.Okta.Client.Cache.DefaultTti = i
-	return c
-}
-
-func (c *Config) WithConnectionTimeout(i int32) *Config {
-	c.Okta.Client.ConnectionTimeout = i
-	return c
-}
-
-func (c *Config) WithProxyPort(i int32) *Config {
-	c.Okta.Client.Proxy.Port = i
-	return c
-}
-
-func (c *Config) WithProxyHost(host string) *Config {
-	c.Okta.Client.Proxy.Host = host
-	return c
-}
-
-func (c *Config) WithProxyUsername(username string) *Config {
-	c.Okta.Client.Proxy.Username = username
-	return c
-}
-
-func (c *Config) WithProxyPassword(pass string) *Config {
-	c.Okta.Client.Proxy.Password = pass
-	return c
-}
-
-func (c *Config) WithOrgUrl(url string) *Config {
-	c.Okta.Client.OrgUrl = url
-	return c
-}
-
-func (c *Config) WithToken(token string) *Config {
-	c.Okta.Client.Token = token
-	return c
-}
-
-func (c *Config) WithUserAgentExtra(s string) *Config {
-	c.UserAgentExtra = s
-	return c
-}
-
-func readConfigFromSystem(c Config) Config {
-	currUser, err := user.Current()
-	if err != nil {
-		return c
+func WithCacheTtl(i int32) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Cache.DefaultTtl = i
 	}
-	if currUser.HomeDir == "" {
-		return c
-	}
-
-	return *c.ReadConfigFromFile(currUser.HomeDir + "/.okta/okta.yaml")
 }
 
-func readConfigFromApplication(c Config) Config {
-	return *c.ReadConfigFromFile(".okta.yaml")
+func WithCacheTti(i int32) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Cache.DefaultTti = i
+	}
 }
 
-func readConfigFromEnvironment(c Config) Config {
-	err := envconfig.Process("okta", &c)
-	if err != nil {
-		fmt.Println("error parsing")
-		return c
+func WithConnectionTimeout(i int32) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.ConnectionTimeout = i
 	}
-	return c
+}
+
+func WithProxyPort(i int32) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Proxy.Port = i
+	}
+}
+
+func WithProxyHost(host string) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Proxy.Host = host
+	}
+}
+
+func WithProxyUsername(username string) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Proxy.Username = username
+	}
+}
+
+func WithProxyPassword(pass string) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Proxy.Password = pass
+	}
+}
+
+func WithOrgUrl(url string) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.OrgUrl = url
+	}
+}
+
+func WithToken(token string) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Client.Token = token
+	}
+}
+
+func WithUserAgentExtra(userAgent string) ConfigSetter {
+	return func(c *config) {
+		c.UserAgentExtra = userAgent
+	}
+}
+
+func WithHttpClient(httpClient http.Client) ConfigSetter {
+	return func(c *config) {
+		c.HttpClient = httpClient
+	}
+}
+
+func WithTestingDisableHttpsCheck(httpsCheck bool) ConfigSetter {
+	return func(c *config) {
+		c.Okta.Testing.DisableHttpsCheck = httpsCheck
+	}
 }

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -19,15 +19,21 @@
 package okta
 
 import (
-	"net/http"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os/user"
 
 	"github.com/okta/okta-sdk-golang/okta/cache"
+
+	"github.com/go-yaml/yaml"
+	"github.com/kelseyhightower/envconfig"
 )
 
 const Version = "0.1.0"
 
 type Client struct {
-	config *Config
+	config *config
 
 	requestExecutor *RequestExecutor
 
@@ -46,26 +52,40 @@ type resource struct {
 	client *Client
 }
 
-func NewClient(config *Config, httpClient *http.Client, cacheManager cache.Cache) *Client {
-	if config == nil {
-		config = NewConfig()
+func NewClient(ctx context.Context, conf ...ConfigSetter) (*Client, error) {
+	config := &config{}
+
+	setConfigDefaults(config)
+	config = readConfigFromSystem(*config)
+	config = readConfigFromApplication(*config)
+	config = readConfigFromEnvironment(*config)
+
+	for _, confSetter := range conf {
+		confSetter(config)
 	}
 
 	var oktaCache cache.Cache
 	if !config.Okta.Client.Cache.Enabled {
 		oktaCache = cache.NewNoOpCache()
 	} else {
-		if cacheManager == nil {
+		if config.CacheManager == nil {
 			oktaCache = cache.NewGoCache(config.Okta.Client.Cache.DefaultTtl,
 				config.Okta.Client.Cache.DefaultTti)
 		} else {
-			oktaCache = cacheManager
+			oktaCache = config.CacheManager
 		}
+	}
+
+	config.CacheManager = oktaCache
+
+	config, err := validateConfig(config)
+	if err != nil {
+		panic(err)
 	}
 
 	c := &Client{}
 	c.config = config
-	c.requestExecutor = NewRequestExecutor(nil, oktaCache, config)
+	c.requestExecutor = NewRequestExecutor(&config.HttpClient, oktaCache, config)
 
 	c.resource.client = c
 
@@ -76,13 +96,82 @@ func NewClient(config *Config, httpClient *http.Client, cacheManager cache.Cache
 	c.Session = (*SessionResource)(&c.resource)
 	c.User = (*UserResource)(&c.resource)
 	c.Factor = (*FactorResource)(&c.resource)
-	return c
+	return c, nil
 }
 
-func (c *Client) GetConfig() *Config {
+func (c *Client) GetConfig() *config {
 	return c.config
 }
 
 func (c *Client) GetRequestExecutor() *RequestExecutor {
 	return c.requestExecutor
+}
+
+func setConfigDefaults(c *config) {
+	var conf []ConfigSetter
+
+	conf = append(conf,
+		WithConnectionTimeout(30),
+		WithCache(true),
+		WithCacheTtl(300),
+		WithCacheTti(300),
+		WithUserAgentExtra(""))
+	WithTestingDisableHttpsCheck(false)
+
+	for _, confSetter := range conf {
+		confSetter(c)
+	}
+}
+
+func readConfigFromFile(location string) (*config, error) {
+	yamlConfig, err := ioutil.ReadFile(location)
+
+	if err != nil {
+		return nil, err
+	}
+
+	conf := config{}
+	err = yaml.Unmarshal(yamlConfig, &conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conf, err
+}
+
+func readConfigFromSystem(c config) *config {
+	currUser, err := user.Current()
+	if err != nil {
+		return &c
+	}
+	if currUser.HomeDir == "" {
+		return &c
+	}
+
+	conf, err := readConfigFromFile(currUser.HomeDir + "/.okta/okta.yaml")
+
+	if err != nil {
+		return &c
+	}
+
+	return conf
+}
+
+func readConfigFromApplication(c config) *config {
+	conf, err := readConfigFromFile(".okta.yaml")
+
+	if err != nil {
+		return &c
+	}
+
+	return conf
+}
+
+func readConfigFromEnvironment(c config) *config {
+	err := envconfig.Process("okta", &c)
+	if err != nil {
+		fmt.Println("error parsing")
+		return &c
+	}
+	return &c
 }

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -31,12 +31,12 @@ import (
 
 type RequestExecutor struct {
 	httpClient *http.Client
-	config     *Config
+	config     *config
 	BaseUrl    *url.URL
 	cache      cache.Cache
 }
 
-func NewRequestExecutor(httpClient *http.Client, cache cache.Cache, config *Config) *RequestExecutor {
+func NewRequestExecutor(httpClient *http.Client, cache cache.Cache, config *config) *RequestExecutor {
 	re := RequestExecutor{}
 	re.httpClient = httpClient
 	re.config = config

--- a/okta/userAgent.go
+++ b/okta/userAgent.go
@@ -25,10 +25,10 @@ type UserAgent struct {
 
 	osVersion string
 
-	config *Config
+	config *config
 }
 
-func NewUserAgent(config *Config) UserAgent {
+func NewUserAgent(config *config) UserAgent {
 	ua := UserAgent{}
 	ua.config = config
 	ua.goVersion = runtime.Version()

--- a/okta/validator.go
+++ b/okta/validator.go
@@ -53,7 +53,7 @@ func validateApiToken(c *config) error {
 		return errors.New("your Okta API token is missing. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token")
 	}
 
-	if strings.Contains(c.Okta.Client.Token, "{apitoken}") {
+	if strings.Contains(c.Okta.Client.Token, "{apiToken}") {
 		return errors.New("replace {apiToken} with your Okta API token. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token")
 	}
 	return nil

--- a/okta/validator.go
+++ b/okta/validator.go
@@ -1,0 +1,60 @@
+package okta
+
+import (
+	"errors"
+	"strings"
+)
+
+func validateConfig(c *config) (*config, error) {
+	var err error
+
+	err = validateOktaDomain(c)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateApiToken(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func validateOktaDomain(c *config) error {
+	if c.Okta.Client.OrgUrl == "" {
+		return errors.New("your Okta URL is missing. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain")
+	}
+
+	if strings.Contains(c.Okta.Client.OrgUrl, "{yourOktaDomain}") {
+		return errors.New("replace {yourOktaDomain} with your Okta domain. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain")
+	}
+
+	if strings.Contains(c.Okta.Client.OrgUrl, "-admin.okta.com") ||
+		strings.Contains(c.Okta.Client.OrgUrl, "-admin.oktapreview.com") ||
+		strings.Contains(c.Okta.Client.OrgUrl, "-admin.okta-emea.com") {
+		return errors.New("your Okta domain should not contain -admin. Current value: " + c.Okta.Client.OrgUrl + ". You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain")
+	}
+
+	if strings.HasSuffix(c.Okta.Client.OrgUrl, ".com.com") {
+		return errors.New("it looks like there's a typo in your Okta domain. Current value: " + c.Okta.Client.OrgUrl + ". You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain")
+	}
+
+	if c.Okta.Testing.DisableHttpsCheck == false {
+		if strings.HasPrefix(c.Okta.Client.OrgUrl, "https://") != true {
+			return errors.New("your Okta URL must start with https. Current value: " + c.Okta.Client.OrgUrl + ". You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain")
+		}
+	}
+	return nil
+}
+
+func validateApiToken(c *config) error {
+	if c.Okta.Client.Token == "" {
+		return errors.New("your Okta API token is missing. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token")
+	}
+
+	if strings.Contains(c.Okta.Client.Token, "{apitoken}") {
+		return errors.New("replace {apiToken} with your Okta API token. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token")
+	}
+	return nil
+}

--- a/openapi/generator/templates/okta.go.hbs
+++ b/openapi/generator/templates/okta.go.hbs
@@ -3,15 +3,21 @@
 package okta
 
 import (
-	"net/http"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os/user"
 
 	"github.com/okta/okta-sdk-golang/okta/cache"
+
+	"github.com/go-yaml/yaml"
+	"github.com/kelseyhightower/envconfig"
 )
 
 const Version = "0.1.0"
 
 type Client struct {
-	config *Config
+	config *config
 
 	requestExecutor *RequestExecutor
 
@@ -24,38 +30,120 @@ type resource struct {
 	client *Client
 }
 
-func NewClient(config *Config, httpClient *http.Client, cacheManager cache.Cache) *Client {
-	if config == nil {
-		config = NewConfig()
-	}
+func NewClient(ctx context.Context, conf ...ConfigSetter) (*Client, error) {
+	config := &config{}
 
+	setConfigDefaults(config)
+	config = readConfigFromSystem(*config)
+	config = readConfigFromApplication(*config)
+	config = readConfigFromEnvironment(*config)
+
+	for _, confSetter := range conf {
+		confSetter(config)
+	}
 
 	var oktaCache cache.Cache
 	if !config.Okta.Client.Cache.Enabled {
 		oktaCache = cache.NewNoOpCache()
 	} else {
-		if cacheManager == nil {
+		if config.CacheManager == nil {
 			oktaCache = cache.NewGoCache(config.Okta.Client.Cache.DefaultTtl,
-			config.Okta.Client.Cache.DefaultTti)
+				config.Okta.Client.Cache.DefaultTti)
 		} else {
-			oktaCache = cacheManager
+			oktaCache = config.CacheManager
 		}
+	}
+
+	config.CacheManager = oktaCache
+
+	config, err := validateConfig(config)
+	if err != nil {
+		panic(err)
 	}
 
 	c := &Client{}
 	c.config = config
-	c.requestExecutor = NewRequestExecutor(nil, oktaCache, config)
+	c.requestExecutor = NewRequestExecutor(&config.HttpClient, oktaCache, config)
 
 	c.resource.client = c
 
 	{{{getNewClientTagProps operations}}}
-	return c
+	return c, nil
 }
 
-func (c *Client) GetConfig() *Config {
+func (c *Client) GetConfig() *config {
 	return c.config
 }
 
 func (c *Client) GetRequestExecutor() *RequestExecutor {
 	return c.requestExecutor
+}
+
+func setConfigDefaults(c *config) {
+	var conf []ConfigSetter
+
+	conf = append(conf,
+		WithConnectionTimeout(30),
+		WithCache(true),
+		WithCacheTtl(300),
+		WithCacheTti(300),
+		WithUserAgentExtra(""))
+		WithTestingDisableHttpsCheck(false)
+
+	for _, confSetter := range conf {
+		confSetter(c)
+	}
+}
+
+func readConfigFromFile(location string) (*config, error) {
+	yamlConfig, err := ioutil.ReadFile(location)
+
+	if err != nil {
+		return nil, err
+	}
+
+	conf := config{}
+	err = yaml.Unmarshal(yamlConfig, &conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &conf, err
+}
+
+func readConfigFromSystem(c config) *config {
+	currUser, err := user.Current()
+	if err != nil {
+		return &c
+	}
+	if currUser.HomeDir == "" {
+		return &c
+	}
+
+	conf, err := readConfigFromFile(currUser.HomeDir + "/.okta/okta.yaml")
+
+	if err != nil {
+		return &c
+	}
+
+	return conf
+}
+
+func readConfigFromApplication(c config) *config {
+	conf, err := readConfigFromFile(".okta.yaml")
+
+	if err != nil {
+		return &c
+	}
+
+	return conf
+}
+
+func readConfigFromEnvironment(c config) *config {
+	err := envconfig.Process("okta", &c)
+	if err != nil {
+		fmt.Println("error parsing")
+		return &c
+	}
+	return &c
 }

--- a/tests/integration/application_test.go
+++ b/tests/integration/application_test.go
@@ -205,7 +205,7 @@ func Test_list_application_allows_casting_to_correct_type(t *testing.T) {
 	require.NoError(t, err, "Deleting an application should not error")
 }
 
-func Test_can_activate_and_deactivate_application(t *testing.T) {
+func Test_can_activate_application(t *testing.T) {
 	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
@@ -225,12 +225,38 @@ func Test_can_activate_and_deactivate_application(t *testing.T) {
 
 	assert.Equal(t, "INACTIVE", application.(*okta.BasicAuthApplication).Status, "Application is not inactive")
 
-	client.Application.ActivateApplication(appId)
+	_, err = client.Application.ActivateApplication(appId)
 	require.NoError(t, err, "Activationg an application should not error")
 	application, _, _ = client.Application.GetApplication(appId, okta.NewBasicAuthApplication(), nil)
 	assert.Equal(t, "ACTIVE", application.(*okta.BasicAuthApplication).Status, "Application is not inactive")
 
 	client.Application.DeactivateApplication(appId)
+	_, err = client.Application.DeleteApplication(appId)
+
+	require.NoError(t, err, "Deleting an application should not error")
+}
+
+func Test_can_deactivate_application(t *testing.T) {
+	client, _ := tests.NewClient()
+
+	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
+	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
+	basicApplicationSettingsApplication.Url = "https://example.com/auth.html"
+
+	basicApplicationSettings := okta.NewBasicApplicationSettings()
+	basicApplicationSettings.App = basicApplicationSettingsApplication
+
+	basicApplication := okta.NewBasicAuthApplication()
+	basicApplication.Settings = basicApplicationSettings
+
+	application, _, err := client.Application.CreateApplication(basicApplication, query.NewQueryParams(query.WithActivate(true)))
+	require.NoError(t, err, "Creating an application should not error")
+
+	appId := application.(*okta.BasicAuthApplication).Id
+
+	assert.Equal(t, "ACTIVE", application.(*okta.BasicAuthApplication).Status, "Application is not inactive")
+
+	_, err = client.Application.DeactivateApplication(appId)
 	require.NoError(t, err, "Deactivating an application should not error")
 	application, _, err = client.Application.GetApplication(appId, okta.NewBasicAuthApplication(), nil)
 	assert.Equal(t, "INACTIVE", application.(*okta.BasicAuthApplication).Status, "Application is not inactive")

--- a/tests/integration/application_test.go
+++ b/tests/integration/application_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Test_can_get_applicaiton_by_id(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -59,7 +59,7 @@ func Test_can_get_applicaiton_by_id(t *testing.T) {
 }
 
 func Test_can_update_application(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -98,7 +98,7 @@ func Test_can_update_application(t *testing.T) {
 }
 
 func Test_can_create_a_bookmark_application(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	bookmarkApplicationSettingsApplication := okta.NewBookmarkApplicationSettingsApplication()
 	bookmarkApplicationSettingsApplication.RequestIntegration = new(bool)
@@ -123,7 +123,7 @@ func Test_can_create_a_bookmark_application(t *testing.T) {
 }
 
 func Test_can_create_a_basic_authentication_application(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -150,7 +150,7 @@ func Test_can_create_a_basic_authentication_application(t *testing.T) {
 }
 
 func Test_list_application_allows_casting_to_correct_type(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -206,7 +206,7 @@ func Test_list_application_allows_casting_to_correct_type(t *testing.T) {
 }
 
 func Test_can_activate_and_deactivate_application(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -241,7 +241,7 @@ func Test_can_activate_and_deactivate_application(t *testing.T) {
 }
 
 func Test_can_add_and_remove_application_users(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -314,7 +314,7 @@ func Test_can_add_and_remove_application_users(t *testing.T) {
 }
 
 func Test_can_set_application_settings_during_creation(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"
@@ -335,7 +335,7 @@ func Test_can_set_application_settings_during_creation(t *testing.T) {
 }
 
 func Test_can_set_application_settings_during_update(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	basicApplicationSettingsApplication := okta.NewBasicApplicationSettingsApplication()
 	basicApplicationSettingsApplication.AuthURL = "https://example.com/auth.html"

--- a/tests/integration/factor_test.go
+++ b/tests/integration/factor_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_exercise_factor_lifecycle(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 
 	user, _, err := client.User.GetUser("john-factor-lifecycle@example.com")
 	if user != nil {

--- a/tests/integration/group_test.go
+++ b/tests/integration/group_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Test_can_get_a_group(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a new group → POST /api/v1/groups
 	gp := &okta.GroupProfile{
 		Name: "Get Test Group",
@@ -59,7 +59,7 @@ func Test_can_get_a_group(t *testing.T) {
 }
 
 func Test_can_list_groups(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a new group → POST /api/v1/groups
 	gp := &okta.GroupProfile{
 		Name: "List Test Group",
@@ -88,7 +88,7 @@ func Test_can_list_groups(t *testing.T) {
 }
 
 func Test_can_search_for_a_group(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a new group → POST /api/v1/groups
 	gp := &okta.GroupProfile{
 		Name: "Search Test Group",
@@ -118,7 +118,7 @@ func Test_can_search_for_a_group(t *testing.T) {
 }
 
 func Test_can_update_a_group(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a new group → POST /api/v1/groups
 	gp := &okta.GroupProfile{
 		Name: "Update Test Group",
@@ -147,7 +147,7 @@ func Test_can_update_a_group(t *testing.T) {
 }
 
 func Test_group_user_operations(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a user with credentials → POST /api/v1/users?activate=false
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -210,7 +210,7 @@ func Test_group_user_operations(t *testing.T) {
 }
 
 func Test_group_rule_operations(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a user with credentials, activated by default → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",

--- a/tests/integration/user_test.go
+++ b/tests/integration/user_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Test_can_get_a_user(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create user with credentials → POST /api/v1/users?activate=false
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -76,7 +76,7 @@ func Test_can_get_a_user(t *testing.T) {
 }
 
 func Test_can_activate_a_user(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	//Create user with credentials → POST /api/v1/users?activate=false
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -126,7 +126,7 @@ func Test_can_activate_a_user(t *testing.T) {
 }
 
 func Test_can_update_user_profile(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create user with credentials → POST /api/v1/users?activate=false
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -172,7 +172,7 @@ func Test_can_update_user_profile(t *testing.T) {
 }
 
 func Test_can_suspend_a_user(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	//Create user with credentials → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -235,7 +235,7 @@ func Test_can_suspend_a_user(t *testing.T) {
 }
 
 func Test_can_change_users_password(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create user with credentials → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -294,7 +294,7 @@ func Test_can_change_users_password(t *testing.T) {
 }
 
 func Test_can_get_reset_password_link_for_user(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create user with credentials → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -338,7 +338,7 @@ func Test_can_get_reset_password_link_for_user(t *testing.T) {
 }
 
 func Test_can_expire_a_users_password_and_get_a_temp_one(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a user with credentials, activated by default → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -382,7 +382,7 @@ func Test_can_expire_a_users_password_and_get_a_temp_one(t *testing.T) {
 }
 
 func Test_can_change_user_recovery_question(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a user with credentials, activated by default → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -454,7 +454,7 @@ func Test_can_change_user_recovery_question(t *testing.T) {
 }
 
 func Test_can_assign_a_user_to_a_role(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a user with credentials, activated by default → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",
@@ -526,7 +526,7 @@ func Test_can_assign_a_user_to_a_role(t *testing.T) {
 }
 
 func Test_user_group_target_role(t *testing.T) {
-	client := tests.NewClient()
+	client, _ := tests.NewClient()
 	// Create a user with credentials, activated by default → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
 		Value: "Abcd1234",

--- a/tests/testCommon.go
+++ b/tests/testCommon.go
@@ -17,12 +17,11 @@
 package tests
 
 import (
+	"context"
+
 	"github.com/okta/okta-sdk-golang/okta"
 )
 
-func NewClient() *okta.Client {
-	config := okta.NewConfig().WithCache(false)
-	client := okta.NewClient(config, nil, nil)
-
-	return client
+func NewClient(conf ...okta.ConfigSetter) (*okta.Client, error) {
+	return okta.NewClient(context.Background(), conf...)
 }

--- a/tests/unit/client_config_test.go
+++ b/tests/unit/client_config_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 - Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit
+
+import (
+	"testing"
+
+	"github.com/okta/okta-sdk-golang/okta"
+
+	"github.com/okta/okta-sdk-golang/tests"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_panic_on_empty_url(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithOrgUrl(""))
+	}, "Does not panic when org url is missing")
+}
+
+func Test_panic_when_url_contains_yourOktaDomain(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithOrgUrl("https://{yourOktaDomain}"))
+	}, "Does not panic when org url contains {yourOktaDomain}")
+}
+
+func Test_panic_when_url_contains_admin_okta_com(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithOrgUrl("https://test-admin.okta.com"))
+	}, "Does not panic when org url contains test-admin.okta.com")
+}
+
+func Test_panic_when_url_contains_admin_oktapreview_com(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithOrgUrl("https://test-admin.oktapreview.com"))
+	}, "Does not panic when org url contains test-admin.oktapreview.com")
+}
+
+func Test_panic_when_url_contains_admin_okta_emea_com(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithOrgUrl("https://test-admin.okta-emea.com"))
+	}, "Does not panic when org url contains test-admin.okta-emea.com")
+}
+
+func Test_panic_when_url_contains_com_com(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithOrgUrl("https://test.okta.com.com"))
+	}, "Does not panic when org url contains .com.com")
+}
+
+func Test_panic_when_url_does_not_begin_with_https(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithTestingDisableHttpsCheck(false), okta.WithOrgUrl("http://test.okta.com"))
+	}, "Does not panic when url contains only http")
+}
+
+func Test_panic_when_api_token_is_empty(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithToken(""))
+	}, "Does not panic when api token is empty")
+}
+
+func Test_panic_when_api_token_contains_placeholder(t *testing.T) {
+	assert.Panics(t, func() {
+		_, _ = tests.NewClient(okta.WithToken(""))
+	}, "Does not panic when api token contains {apiToken}")
+}

--- a/tests/unit/client_config_test.go
+++ b/tests/unit/client_config_test.go
@@ -75,6 +75,6 @@ func Test_panic_when_api_token_is_empty(t *testing.T) {
 
 func Test_panic_when_api_token_contains_placeholder(t *testing.T) {
 	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithToken(""))
+		_, _ = tests.NewClient(okta.WithToken("{apiToken}"))
 	}, "Does not panic when api token contains {apiToken}")
 }


### PR DESCRIPTION
I have added configuration checks which resolves OKTA-221069

This change breaks the way config and client generation is done.  You no longer pass in a config object into the client, but rather pass in the `With*` methods in as the final properties for the client.

```
client, err := okta.NewClient(context, okta.WithOrgUrl(""), okta.WithToken("xxxxx")
```

if an error shows in the configuration, a panic will be triggered preventing the app from running.


Readme has been updated to reflect this.