### PR TITLE
Fix in fetch applications

### DIFF
--- a/okta/application.go
+++ b/okta/application.go
@@ -111,12 +111,16 @@ func (m *ApplicationResource) ListApplications(qp *query.Params) ([]App, *Respon
 		return nil, nil, err
 	}
 
-	var application []App
+	var application []*Application
 	resp, err := m.client.requestExecutor.Do(req, &application)
 	if err != nil {
 		return nil, resp, err
 	}
-	return application, resp, nil
+	var appList []App
+	for _, app := range application {
+		appList = append(appList, app)
+	}
+	return appList, resp, nil
 }
 func (m *ApplicationResource) CreateApplication(body App, qp *query.Params) (interface{}, *Response, error) {
 	url := fmt.Sprintf("/api/v1/apps")


### PR DESCRIPTION
Current behaviour: Request to fetch application fails as the response cannot be parsed to the interface
Expected Behaviour: Request to fetch application should return the list of applications registered on Okta without any errors
Bug Reason: The response is being parsed to App interface instead of Application struct
Fix: Parse the response to a list of Application pointers and then return them as an interface