### PR TITLE
Allow for RequestExecutor to be created without an API token

### DIFF
--- a/okta/validator.go
+++ b/okta/validator.go
@@ -5,15 +5,15 @@ import (
 	"strings"
 )
 
-func validateConfig(c *config) (*config, error) {
+func ValidateConfig(c *config) (*config, error) {
 	var err error
 
-	err = validateOktaDomain(c)
+	err = ValidateOktaDomain(c)
 	if err != nil {
 		return nil, err
 	}
 
-	err = validateApiToken(c)
+	err = ValidateApiToken(c)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func validateConfig(c *config) (*config, error) {
 	return c, nil
 }
 
-func validateOktaDomain(c *config) error {
+func ValidateOktaDomain(c *config) error {
 	if c.Okta.Client.OrgUrl == "" {
 		return errors.New("your Okta URL is missing. You can copy your domain from the Okta Developer Console. Follow these instructions to find it: https://bit.ly/finding-okta-domain")
 	}
@@ -48,7 +48,7 @@ func validateOktaDomain(c *config) error {
 	return nil
 }
 
-func validateApiToken(c *config) error {
+func ValidateApiToken(c *config) error {
 	if c.Okta.Client.Token == "" {
 		return errors.New("your Okta API token is missing. You can generate one in the Okta Developer Console. Follow these instructions: https://bit.ly/get-okta-api-token")
 	}


### PR DESCRIPTION
Factor NewConfig and NewCache out of NewClient.  Expose the config validators.  This allows creating a RequestExecutor without calling NewClient.  Since NewClient panics when no API token is given, this provides a way to do simple Okta logins without an API token.