### PR TITLE
Return error on configuration validation error.

### DIFF
--- a/okta/okta.go
+++ b/okta/okta.go
@@ -80,7 +80,7 @@ func NewClient(ctx context.Context, conf ...ConfigSetter) (*Client, error) {
 
 	config, err := validateConfig(config)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	c := &Client{}

--- a/openapi/generator/templates/okta.go.hbs
+++ b/openapi/generator/templates/okta.go.hbs
@@ -58,7 +58,7 @@ func NewClient(ctx context.Context, conf ...ConfigSetter) (*Client, error) {
 
 	config, err := validateConfig(config)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	c := &Client{}

--- a/tests/unit/client_config_test.go
+++ b/tests/unit/client_config_test.go
@@ -25,74 +25,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_panic_on_empty_url(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithOrgUrl(""))
-	}, "Does not panic when org url is missing")
+func Test_error_on_empty_url(t *testing.T) {
+	_, err := tests.NewClient(okta.WithOrgUrl(""))
+	assert.Error(t, err, "Does not error when org url is missing")
 }
 
-func Test_panic_when_url_contains_yourOktaDomain(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithOrgUrl("https://{yourOktaDomain}"))
-	}, "Does not panic when org url contains {yourOktaDomain}")
+func Test_error_when_url_contains_yourOktaDomain(t *testing.T) {
+	_, err := tests.NewClient(okta.WithOrgUrl("https://{yourOktaDomain}"))
+	assert.Error(t, err, "Does not error when org url contains {yourOktaDomain}")
 }
 
-func Test_panic_when_url_contains_admin_okta_com(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithOrgUrl("https://test-admin.okta.com"))
-	}, "Does not panic when org url contains test-admin.okta.com")
+func Test_error_when_url_contains_admin_okta_com(t *testing.T) {
+	_, err := tests.NewClient(okta.WithOrgUrl("https://test-admin.okta.com"))
+	assert.Error(t, err, "Does not error when org url contains test-admin.okta.com")
 }
 
-func Test_panic_when_url_contains_admin_oktapreview_com(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithOrgUrl("https://test-admin.oktapreview.com"))
-	}, "Does not panic when org url contains test-admin.oktapreview.com")
+func Test_error_when_url_contains_admin_oktapreview_com(t *testing.T) {
+	_, err := tests.NewClient(okta.WithOrgUrl("https://test-admin.oktapreview.com"))
+	assert.Error(t, err, "Does not error when org url contains test-admin.oktapreview.com")
 }
 
-func Test_panic_when_url_contains_admin_okta_emea_com(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithOrgUrl("https://test-admin.okta-emea.com"))
-	}, "Does not panic when org url contains test-admin.okta-emea.com")
+func Test_error_when_url_contains_admin_okta_emea_com(t *testing.T) {
+	_, err := tests.NewClient(okta.WithOrgUrl("https://test-admin.okta-emea.com"))
+	assert.Error(t, err, "Does not error when org url contains test-admin.okta-emea.com")
 }
 
-func Test_panic_when_url_contains_com_com(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithOrgUrl("https://test.okta.com.com"))
-	}, "Does not panic when org url contains .com.com")
+func Test_error_when_url_contains_com_com(t *testing.T) {
+	_, err := tests.NewClient(okta.WithOrgUrl("https://test.okta.com.com"))
+	assert.Error(t, err, "Does not error when org url contains .com.com")
 }
 
-func Test_panic_when_url_does_not_begin_with_https(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithTestingDisableHttpsCheck(false), okta.WithOrgUrl("http://test.okta.com"))
-	}, "Does not panic when url contains only http")
+func Test_error_when_url_does_not_begin_with_https(t *testing.T) {
+	_, err := tests.NewClient(okta.WithTestingDisableHttpsCheck(false), okta.WithOrgUrl("http://test.okta.com"))
+	assert.Error(t, err, "Does not error when url contains only http")
 }
 
-func Test_panic_when_api_token_is_empty(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithToken(""))
-	}, "Does not panic when api token is empty")
+func Test_error_when_api_token_is_empty(t *testing.T) {
+	_, err := tests.NewClient(okta.WithToken(""))
+	assert.Error(t, err, "Does not error when api token is empty")
 }
 
-func Test_panic_when_api_token_contains_placeholder(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithToken("{apiToken}"))
-	}, "Does not panic when api token contains {apiToken}")
+func Test_error_when_api_token_contains_placeholder(t *testing.T) {
+	_, err := tests.NewClient(okta.WithToken("{apiToken}"))
+	assert.Error(t, err, "Does not error when api token contains {apiToken}")
 }
 
-func Test_panic_when_authorization_mode_is_not_valid(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithAuthorizationMode("invalid"))
-	}, "Does not panic when authorization mode is invalid")
+func Test_error_when_authorization_mode_is_not_valid(t *testing.T) {
+	_, err := tests.NewClient(okta.WithAuthorizationMode("invalid"))
+	assert.Error(t, err, "Does not error when authorization mode is invalid")
 }
 
-func Test_does_not_panic_when_authorization_mode_is_valid(t *testing.T) {
-	assert.NotPanics(t, func() {
-		_, _ = tests.NewClient(okta.WithAuthorizationMode("SSWS"))
-	}, "Should not panic when authorization mode is SSWS")
+func Test_does_not_error_when_authorization_mode_is_valid(t *testing.T) {
+	_, err := tests.NewClient(okta.WithAuthorizationMode("SSWS"))
+	assert.NoError(t, err, "Should not error when authorization mode is SSWS")
 }
 
-func Test_will_panic_if_private_key_authorization_type_with_missing_properties(t *testing.T) {
-	assert.Panics(t, func() {
-		_, _ = tests.NewClient(okta.WithAuthorizationMode("PrivateKey"), okta.WithClientId(""))
-	}, "Does not panic if private key selected with no other required options")
+func Test_will_error_if_private_key_authorization_type_with_missing_properties(t *testing.T) {
+	_, err := tests.NewClient(okta.WithAuthorizationMode("PrivateKey"), okta.WithClientId(""))
+	assert.Error(t, err, "Does not error if private key selected with no other required options")
 }


### PR DESCRIPTION
Replaces a panic in NewClient. Tests are updated, note that currently
failing test Test_does_not_error_when_authorization_mode_is_valid is
still failing in this PR. I did not attempt to change any testing logic
outside the changes necessary for this PR.

Fixes #122