### PR TITLE
Using int64 for timeout settings

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -36,8 +36,8 @@ type config struct {
 				Username string `yaml:"username" envconfig:"OKTA_CLIENT_PROXY_USERNAME"`
 				Password string `yaml:"password" envconfig:"OKTA_CLIENT_PROXY_PASSWORD"`
 			} `yaml:"proxy"`
-			ConnectionTimeout int32 `yaml:"connectionTimeout" envconfig:"OKTA_CLIENT_CONNECTION_TIMEOUT"`
-			RequestTimeout    int32 `yaml:"requestTimeout" envconfig:"OKTA_CLIENT_REQUEST_TIMEOUT"`
+			ConnectionTimeout int64 `yaml:"connectionTimeout" envconfig:"OKTA_CLIENT_CONNECTION_TIMEOUT"`
+			RequestTimeout    int64 `yaml:"requestTimeout" envconfig:"OKTA_CLIENT_REQUEST_TIMEOUT"`
 			RateLimit         struct {
 				MaxRetries int32 `yaml:"maxRetries" envconfig:"OKTA_CLIENT_RATE_LIMIT_MAX_RETRIES"`
 			} `yaml:"rateLimit"`
@@ -83,7 +83,7 @@ func WithCacheTti(i int32) ConfigSetter {
 	}
 }
 
-func WithConnectionTimeout(i int32) ConfigSetter {
+func WithConnectionTimeout(i int64) ConfigSetter {
 	return func(c *config) {
 		c.Okta.Client.ConnectionTimeout = i
 	}
@@ -143,7 +143,7 @@ func WithTestingDisableHttpsCheck(httpsCheck bool) ConfigSetter {
 	}
 }
 
-func WithRequestTimeout(requestTimeout int32) ConfigSetter {
+func WithRequestTimeout(requestTimeout int64) ConfigSetter {
 	return func(c *config) {
 		c.Okta.Client.RequestTimeout = requestTimeout
 	}


### PR DESCRIPTION
Uses int64 for ConnectionTimeout and RequestTimeout to match the built-in "time" libraries underlying types.

Made for #147 