### PR TITLE
Adding name to policy rule struct

### DIFF
--- a/okta/policyRule.go
+++ b/okta/policyRule.go
@@ -29,6 +29,7 @@ type PolicyRuleResource resource
 type PolicyRule struct {
 	Created     *time.Time `json:"created,omitempty"`
 	Id          string     `json:"id,omitempty"`
+	Name        string     `json:"name,omitempty"`
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
 	Priority    int64      `json:"priority,omitempty"`
 	Status      string     `json:"status,omitempty"`


### PR DESCRIPTION
Per the docs on Policy Objects at https://developer.okta.com/docs/reference/api/policy/#rules-object

The name field should be considered part of the default set for all policies.