### PR TITLE
Move upgrade guide in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * [Getting started](#getting-started)
 * [Usage guide](#usage-guide)
 * [Configuration reference](#configuration-reference)
+* [Upgrading Guide](#upgrading-to-2.0.x)
 * [Building the SDK](#building-the-sdk)
 * [Contributing](#contributing)
 
@@ -65,101 +66,6 @@ ctx, client, err := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDo
 ```
 
 Hard-coding the Okta domain and API token works for quick tests, but for real projects you should use a more secure way of storing these values (such as environment variables). This library supports a few different configuration sources, covered in the [configuration reference](#configuration-reference) section.
-
-## Upgrading to 2.0.x
-The main purpose of this version is to include all documented, application/json endpoints
-to the SDK. During this update we have made many changes to method names, as well as method signatures.
-
-### Context
-Every method that calls the API now has the ability to pass `context.Context` to it as the first parameter. If you do not have a context or do not know which context to use, you can pass `context.TODO()` to the methods.
-
-### Method changes
-We have spent time during this update making sure we become a little more uniform with naming of methods. This will require you to update some of your calls to the SDK with the new names.
-
-All methods now specify the `Accept` and `Content-Type` headers when creating a new request. This allows for future use of the SDK to handle multiple `Accept` types.
-
-### OAuth 2.0
-
-Okta allows you to interact with Okta APIs using scoped OAuth 2.0 access tokens. Each access token enables the bearer to perform specific actions on specific Okta endpoints, with that ability controlled by which scopes the access token contains.
-
-This SDK supports this feature only for service-to-service applications. Check out [our guides](https://developer.okta.com/docs/guides/implement-oauth-for-okta/overview/) to learn more about how to register a new service application using a private and public key pair.
-
-When using this approach you won't need an API Token because the SDK will request an access token for you. In order to use OAuth 2.0, construct a client instance by passing the following parameters:
-
-```
-ctx, client, err := okta.NewClient(context,
-  okta.WithAuthorizationMode("PrivateKey"),
-  okta.WithClientId("{{clientId}}),
-  okta.WithScopes(([]string{"okta.users.manage"})),
-  okta.WithPrivateKey({{PEM PRIVATE KEY BLOCK}}) //when pasting blocks, use backticks and remove all space at begining of each line.
-)
-```
-
-### Extending the Client
-When calling `okta.NewClient()` we allow for you to pass custom instances of `http.Client` and `cache.Cache`.
-
-```
-myClient := &http.Client{}
-
-myCache := NewCustomCacheDriver()
-
-ctx, client, err := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"), okta.WithHttpClient(myClient), okta.WithCacheManager(myCache))
-```
-
-
-### Extending or Creating New Cache Manager
-You can create a custom cache driver by implementing `cache.Cache`
-
-```
-type CustomCacheDriver struct {
-}
-
-func NewCustomCacheDriver() Cache {
-	return CustomCacheDriver{}
-}
-
-func (c CustomCacheDriver) Get(key string) *http.Response {
-	return nil
-}
-
-func (c CustomCacheDriver) Set(key string, value *http.Response) {}
-
-func (c CustomCacheDriver) Delete(key string) {}
-
-func (c CustomCacheDriver) Clear() {}
-
-func (c CustomCacheDriver) Has(key string) bool {
-	return false
-}
-```
-
-### Refreshing Cache for Specific Call
-If you have an issue where you do a `GET`, then a `DELETE`, and then re-issue a `GET` to the original endpoint, you may have an issue with the cache returning with the deleted resource. An example of this is listing applicaiton users, delete and application user, and them listing them again.
-
-You can solve this by running `client.GetRequestExecutor().RefreshNext()` before your second `ListApplicationUsers` call, which will tell the call to delete the cache for this endpoint and make a new call.
-
-```go
-appUserList, _, _ = client.Application.ListApplicationUsers(context.TODO(), appId, nil)
-
-client.Application.DeleteApplicationUser(context.TODO(), appId, appUser.Id, nil)
-
-client.GetRequestExecutor().RefreshNext()
-appUserList, _, _ = client.Application.ListApplicationUsers(context.TODO(), appId, nil)
-```
-
-### Pagination
-If your request comes back with more than the default or set limit, you can request the next page.
-
-Exmaple of listing users 1 at a time:
-```go
-query := query.NewQueryParams(query.WithLimit(1))
-users, resp, err := client.User.ListUsers(ctx, query)
-// Do something with your users until you run out of users to iterate.
-if resp.HasNextPage() {
-  var nextUserSet []*okta.User
-  resp, err = resp.Next(ctx, &nextUserSet)
-}
-```
 
 ## Usage guide
 
@@ -481,6 +387,101 @@ Each one of the configuration values above can be turned into an environment var
 * `OKTA_CLIENT_CONNECTIONTIMEOUT`
 * `OKTA_CLIENT_TOKEN`
 * and so on
+
+## Upgrading to 2.0.x
+The main purpose of this version is to include all documented, application/json endpoints
+to the SDK. During this update we have made many changes to method names, as well as method signatures.
+
+### Context
+Every method that calls the API now has the ability to pass `context.Context` to it as the first parameter. If you do not have a context or do not know which context to use, you can pass `context.TODO()` to the methods.
+
+### Method changes
+We have spent time during this update making sure we become a little more uniform with naming of methods. This will require you to update some of your calls to the SDK with the new names.
+
+All methods now specify the `Accept` and `Content-Type` headers when creating a new request. This allows for future use of the SDK to handle multiple `Accept` types.
+
+### OAuth 2.0
+
+Okta allows you to interact with Okta APIs using scoped OAuth 2.0 access tokens. Each access token enables the bearer to perform specific actions on specific Okta endpoints, with that ability controlled by which scopes the access token contains.
+
+This SDK supports this feature only for service-to-service applications. Check out [our guides](https://developer.okta.com/docs/guides/implement-oauth-for-okta/overview/) to learn more about how to register a new service application using a private and public key pair.
+
+When using this approach you won't need an API Token because the SDK will request an access token for you. In order to use OAuth 2.0, construct a client instance by passing the following parameters:
+
+```
+ctx, client, err := okta.NewClient(context,
+  okta.WithAuthorizationMode("PrivateKey"),
+  okta.WithClientId("{{clientId}}),
+  okta.WithScopes(([]string{"okta.users.manage"})),
+  okta.WithPrivateKey({{PEM PRIVATE KEY BLOCK}}) //when pasting blocks, use backticks and remove all space at begining of each line.
+)
+```
+
+### Extending the Client
+When calling `okta.NewClient()` we allow for you to pass custom instances of `http.Client` and `cache.Cache`.
+
+```
+myClient := &http.Client{}
+
+myCache := NewCustomCacheDriver()
+
+ctx, client, err := okta.NewClient(context, okta.WithOrgUrl("https://{yourOktaDomain}"), okta.WithToken("{apiToken}"), okta.WithHttpClient(myClient), okta.WithCacheManager(myCache))
+```
+
+
+### Extending or Creating New Cache Manager
+You can create a custom cache driver by implementing `cache.Cache`
+
+```
+type CustomCacheDriver struct {
+}
+
+func NewCustomCacheDriver() Cache {
+	return CustomCacheDriver{}
+}
+
+func (c CustomCacheDriver) Get(key string) *http.Response {
+	return nil
+}
+
+func (c CustomCacheDriver) Set(key string, value *http.Response) {}
+
+func (c CustomCacheDriver) Delete(key string) {}
+
+func (c CustomCacheDriver) Clear() {}
+
+func (c CustomCacheDriver) Has(key string) bool {
+	return false
+}
+```
+
+### Refreshing Cache for Specific Call
+If you have an issue where you do a `GET`, then a `DELETE`, and then re-issue a `GET` to the original endpoint, you may have an issue with the cache returning with the deleted resource. An example of this is listing applicaiton users, delete and application user, and them listing them again.
+
+You can solve this by running `client.GetRequestExecutor().RefreshNext()` before your second `ListApplicationUsers` call, which will tell the call to delete the cache for this endpoint and make a new call.
+
+```go
+appUserList, _, _ = client.Application.ListApplicationUsers(context.TODO(), appId, nil)
+
+client.Application.DeleteApplicationUser(context.TODO(), appId, appUser.Id, nil)
+
+client.GetRequestExecutor().RefreshNext()
+appUserList, _, _ = client.Application.ListApplicationUsers(context.TODO(), appId, nil)
+```
+
+### Pagination
+If your request comes back with more than the default or set limit, you can request the next page.
+
+Exmaple of listing users 1 at a time:
+```go
+query := query.NewQueryParams(query.WithLimit(1))
+users, resp, err := client.User.ListUsers(ctx, query)
+// Do something with your users until you run out of users to iterate.
+if resp.HasNextPage() {
+  var nextUserSet []*okta.User
+  resp, err = resp.Next(ctx, &nextUserSet)
+}
+```
 
 ## Building the SDK
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * [Getting started](#getting-started)
 * [Usage guide](#usage-guide)
 * [Configuration reference](#configuration-reference)
-* [Upgrading Guide](#upgrading-to-2.0.x)
+* [Upgrading Guide](#upgrading-to-20x)
 * [Building the SDK](#building-the-sdk)
 * [Contributing](#contributing)
 


### PR DESCRIPTION
This commit moves the upgrade guide lower in the readme so it makes more sense when people are reading the docs. Resolves #159.