### PR TITLE
Fix EOF error check in request retry logic

### DIFF
--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -295,7 +295,7 @@ func (re *RequestExecutor) doWithRetries(ctx context.Context, req *http.Request)
 	}
 	operation := func() error {
 		resp, err = re.httpClient.Do(req.WithContext(ctx))
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// retry on EOF errors, which might be caused by network connectivity issues
 			return fmt.Errorf("network error: %v", err)
 		} else if err != nil {


### PR DESCRIPTION
Relates to https://github.com/okta/okta-sdk-golang/issues/198

I tested the most recent version of master and requests aren't retried on:
```
Post "https://{redacted my custom org domain name}/api/v1/apps": EOF
```
errors.

The error is never equal to `io.EOF`. I hope this example can shed some light on the error checking problem:
```
// server.go
package main

import (
        "log"
        "net/http"
        "time"
)

type handler struct{}

func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
        time.Sleep(2 * time.Second) // handle some logic
        w.Write([]byte("foo"))
}

func main() {
        s := &http.Server{
                Addr:         "127.0.0.1:9999",
                Handler:      &handler{},
                WriteTimeout: 1 * time.Second,
        }
        log.Fatal(s.ListenAndServe())
}
```
```
// client.go
package main

import (
        "errors"
        "fmt"
        "io"
        "net/http"
)

func main() {
        client := http.Client{}
        request, err := http.NewRequest("POST", "http://127.0.0.1:9999", nil)
        if err != nil {
                panic(err)
        }

        _, err = client.Do(request)
        fmt.Println("err:", err)
        fmt.Println("err == io.EOF", err == io.EOF)
        fmt.Println("errors.Is(err, io.EOF)", errors.Is(err, io.EOF))
}
```
```
go run client.go
err: Post "http://127.0.0.1:9999": EOF
err == io.EOF false
errors.Is(err, io.EOF) true
```

I explained further reasons for using `errors.Is` in https://github.com/okta/okta-sdk-golang/pull/199#discussion_r565224331 one reason for not doing it this way. 