### PR TITLE
Fix WithPrivateKey option handling of long strings

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -17,10 +17,12 @@
 package okta
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"syscall"
 
 	"github.com/okta/okta-sdk-golang/v2/okta/cache"
 )
@@ -201,6 +203,9 @@ func WithPrivateKey(privateKey string) ConfigSetter {
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
+		return false
+	}
+	if err != nil && errors.Is(err.(*os.PathError).Err, syscall.ENAMETOOLONG) {
 		return false
 	}
 	return !info.IsDir()

--- a/okta/config.go
+++ b/okta/config.go
@@ -202,10 +202,7 @@ func WithPrivateKey(privateKey string) ConfigSetter {
 
 func fileExists(filename string) bool {
 	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	if err != nil && errors.Is(err.(*os.PathError).Err, syscall.ENAMETOOLONG) {
+	if os.IsNotExist(err) || errors.Is(err, syscall.ENAMETOOLONG) {
 		return false
 	}
 	return !info.IsDir()


### PR DESCRIPTION
Relates to https://github.com/okta/okta-sdk-golang/issues/206

@bogdanprodan-okta @bretterer I'd very much appreciate review on this one. It probably doesn't fix the whole error handling but it's a start which at least unblocks me.