### PR TITLE
Add support for opaque private key signers

### DIFF
--- a/okta/config.go
+++ b/okta/config.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"github.com/okta/okta-sdk-golang/v2/okta/cache"
+	"gopkg.in/square/go-jose.v2"
 )
 
 type config struct {
@@ -58,9 +59,10 @@ type config struct {
 			DisableHttpsCheck bool `yaml:"disableHttpsCheck" envconfig:"OKTA_TESTING_DISABLE_HTTPS_CHECK"`
 		} `yaml:"testing"`
 	} `yaml:"okta"`
-	UserAgentExtra string
-	HttpClient     *http.Client
-	CacheManager   cache.Cache
+	UserAgentExtra   string
+	HttpClient       *http.Client
+	CacheManager     cache.Cache
+	PrivateKeySigner jose.Signer
 }
 
 type ConfigSetter func(*config)
@@ -204,6 +206,12 @@ func WithPrivateKey(privateKey string) ConfigSetter {
 		} else {
 			c.Okta.Client.PrivateKey = privateKey
 		}
+	}
+}
+
+func WithPrivateKeySigner(signer jose.Signer) ConfigSetter {
+	return func(c *config) {
+		c.PrivateKeySigner = signer
 	}
 }
 

--- a/okta/validator.go
+++ b/okta/validator.go
@@ -75,8 +75,9 @@ func validateAuthorization(c *config) error {
 	if c.Okta.Client.AuthorizationMode == "PrivateKey" &&
 		(c.Okta.Client.ClientId == "" ||
 			c.Okta.Client.Scopes == nil ||
-			c.Okta.Client.PrivateKey == "") {
-		return errors.New("when using AuthorizationMode 'PrivateKey', you must supply 'ClientId', 'Scopes', and 'PrivateKey'")
+			(c.Okta.Client.PrivateKey == "" &&
+				c.PrivateKeySigner == nil)) {
+		return errors.New("when using AuthorizationMode 'PrivateKey', you must supply 'ClientId', 'Scopes', and 'PrivateKey' or 'PrivateKeySigner'")
 	}
 
 	return nil


### PR DESCRIPTION
## Why

With the increasing industry use of the OAuth2 `private_key_jwt` client assertion type, there are situations where the private key component is opaque to the process or application utilizing the credentials. The standardized usage of key management services (such as AWS KMS) mean that cryptographic operations are abstracted behind an authenticated API and prevent executed code from ever interacting with raw key material.

Currently, the Okta Go SDK converts the Private Key (plain text or file path) provided into a [jose.Signer](https://pkg.go.dev/gopkg.in/square/go-jose.v2?utm_source=godoc#Signer) under the hood. To facilitate use cases where the raw key material is not available, the [Square Go JOSE v2 library](https://github.com/square/go-jose/tree/v2) includes a [jose.OpaqueSigner](https://pkg.go.dev/gopkg.in/square/go-jose.v2?utm_source=godoc#OpaqueSigner) interface which can be consumed by the [jose.NewSigner](https://pkg.go.dev/gopkg.in/square/go-jose.v2?utm_source=godoc#NewSigner) method (see [signing.go#L209](https://github.com/square/go-jose/blob/5c87222f69b2401c305bcb103b875524e13de347/signing.go#L209) for implementation reference). This PR attempts to extend the capabilities of the Okta Go SDK by allowing developers to provide an already initialized [jose.Signer](https://pkg.go.dev/gopkg.in/square/go-jose.v2?utm_source=godoc#Signer) to a new configuration `okta.WithPrivateKeySigner(jose.Signer)` method.


## Example usage
```go
// Arbitrarily provide the application with an opaque or plain text private key.
privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

// Define the JOSE Signer.
signer, _ := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: privateKey}, nil)

// Define the Okta client, passing in the signer as the PrivateKey.
_, client, _ := okta.NewClient(
	ctx,
	okta.WithOrgUrl("https://example.okta.com"),
	okta.WithAuthorizationMode("PrivateKey"),
	okta.WithClientId("0oajncakofQmjxlSw0h3"),
	okta.WithPrivateKeySigner(signer),
	okta.WithScopes([]string{"oidc", "profile", "email"}),
)
```

## Benefits

- Allows segregation between the private key cryptographic operations and the application. This air-gap provides assurance that if an application is compromised, an attacker will not be able to retrieve the private key plain text.
- Increases the flexibility of the client configuration and allows developers to use non-RSA key pairs.
- Slight performance increase as [requestExecutor.go#L125](https://github.com/okta/okta-sdk-golang/blob/1a53cff27a73667709c38ddb05ab7e34f7164b2a/okta/requestExecutor.go#L125) no longer needs to parse, validate and allocate memory on each access token cache miss. A single [jose.Signer](https://pkg.go.dev/gopkg.in/square/go-jose.v2?utm_source=godoc#Signer) can be re-used for the entire runtime.

## Considerations

If a plaintext private key (`config.Okta.Client.PrivateKey`) is provided, then the request executor will store the generated `jose.Signer` inside the configuration for future use. This differs from the current functionality where the signer is re-generated each time there is a cache miss on retrieving the access token (see dot-point three inside the  **Benefits** section).
