### PR TITLE
Helper branch to emanor-okta's pull/295

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,7 @@ okta:
         THQdM5PIlot6XmeV1KUKuzw2ewDeb5zcasA4QHPcSVh2+KzbttPQ+RUXCUAr5t+r
         0r6gBc5Dy1IPjCFsqsPJXFwqe3RzUb...
         -----END RSA PRIVATE KEY-----
+    privateKeyId: "{JWK key id (kid}" # needed if Okta service application has more then a single JWK registered
     requestTimeout: 0 # seconds
     rateLimit:
       maxRetries: 4
@@ -859,6 +860,7 @@ The client is configured with a configuration setter object passed to the `NewCl
 | WithClientId(clientId string) | Okta App client id, used with `PrivateKey` oauth auth mode |
 | WithScopes(scopes []string) | Okta API app scopes |
 | WithPrivateKey(privateKey string) | Private key value |
+| WithPrivateKeyId(privateKeyId string) | Private key id (kid) value |
 | WithPrivateKeySigner(signer jose.Signer) | Custom private key signer implementing the `jose.Signer` interface |
 
 ### Okta Client Base Configuration
@@ -925,7 +927,8 @@ ctx, client, err := okta.NewClient(ctx,
   okta.WithAuthorizationMode("PrivateKey"),
   okta.WithClientId("{{clientId}}"),
   okta.WithScopes(([]string{"okta.users.manage"})),
-  okta.WithPrivateKey({{PEM PRIVATE KEY BLOCK}}) //when pasting blocks, use backticks and remove all space at beginning of each line.
+  okta.WithPrivateKey({{PEM PRIVATE KEY BLOCK}}), //when pasting blocks, use backticks and remove all space at beginning of each line.
+  okta.WithPrivateKeyId("{{private key id}}"),    //needed if Okta service application has more then a single JWK registered
 )
 if err != nil {
   fmt.Printf("Error: %v\n", err)
@@ -1041,6 +1044,7 @@ ctx, client, err := okta.NewClient(ctx,
   okta.WithClientId("{client_id}"),
   okta.WithScopes([]string{"{scopes}"}),
   okta.WithPrivateKey("{private_key}"),
+  okta.WithPrivateKeyId("{private key id}"), //needed if Okta service application has more then a single JWK registered
   )
 
 ```

--- a/okta/application.go
+++ b/okta/application.go
@@ -153,7 +153,6 @@ func (m *ApplicationResource) ListApplications(ctx context.Context, qp *query.Pa
 		apps[i] = &application[i]
 	}
 	return apps, resp, nil
-
 }
 
 // Adds a new application to your Okta organization.
@@ -824,7 +823,6 @@ func (m *ApplicationResource) UploadApplicationLogo(ctx context.Context, appId s
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	fw, err := writer.CreateFormFile("file", file)
-
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +833,6 @@ func (m *ApplicationResource) UploadApplicationLogo(ctx context.Context, appId s
 	_ = writer.Close()
 
 	req, err := rq.WithAccept("application/json").WithContentType(writer.FormDataContentType()).NewRequest("POST", url, body)
-
 	if err != nil {
 		return nil, err
 	}

--- a/okta/brand.go
+++ b/okta/brand.go
@@ -447,7 +447,6 @@ func (m *BrandResource) UploadBrandThemeBackgroundImage(ctx context.Context, bra
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	fw, err := writer.CreateFormFile("file", file)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -458,7 +457,6 @@ func (m *BrandResource) UploadBrandThemeBackgroundImage(ctx context.Context, bra
 	_ = writer.Close()
 
 	req, err := rq.WithAccept("application/json").WithContentType(writer.FormDataContentType()).NewRequest("POST", url, body)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -506,7 +504,6 @@ func (m *BrandResource) UploadBrandThemeFavicon(ctx context.Context, brandId str
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	fw, err := writer.CreateFormFile("file", file)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -517,7 +514,6 @@ func (m *BrandResource) UploadBrandThemeFavicon(ctx context.Context, brandId str
 	_ = writer.Close()
 
 	req, err := rq.WithAccept("application/json").WithContentType(writer.FormDataContentType()).NewRequest("POST", url, body)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -565,7 +561,6 @@ func (m *BrandResource) UploadBrandThemeLogo(ctx context.Context, brandId string
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	fw, err := writer.CreateFormFile("file", file)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -576,7 +571,6 @@ func (m *BrandResource) UploadBrandThemeLogo(ctx context.Context, brandId string
 	_ = writer.Close()
 
 	req, err := rq.WithAccept("application/json").WithContentType(writer.FormDataContentType()).NewRequest("POST", url, body)
-
 	if err != nil {
 		return nil, nil, err
 	}

--- a/okta/config.go
+++ b/okta/config.go
@@ -54,6 +54,7 @@ type config struct {
 			ClientId          string   `yaml:"clientId" envconfig:"OKTA_CLIENT_CLIENTID"`
 			Scopes            []string `yaml:"scopes" envconfig:"OKTA_CLIENT_SCOPES"`
 			PrivateKey        string   `yaml:"privateKey" envconfig:"OKTA_CLIENT_PRIVATEKEY"`
+                        PrivateKeyId      string   `yaml:"privateKeyId" envconfig:"OKTA_CLIENT_PRIVATEKEYID"`
 		} `yaml:"client"`
 		Testing struct {
 			DisableHttpsCheck bool `yaml:"disableHttpsCheck" envconfig:"OKTA_TESTING_DISABLE_HTTPS_CHECK"`
@@ -207,6 +208,12 @@ func WithPrivateKey(privateKey string) ConfigSetter {
 			c.Okta.Client.PrivateKey = privateKey
 		}
 	}
+}
+
+func WithPrivateKeyId(privateKeyId string) ConfigSetter {
+        return func(c *config) {
+                c.Okta.Client.PrivateKeyId = privateKeyId
+        }
 }
 
 func WithPrivateKeySigner(signer jose.Signer) ConfigSetter {

--- a/okta/config.go
+++ b/okta/config.go
@@ -54,7 +54,7 @@ type config struct {
 			ClientId          string   `yaml:"clientId" envconfig:"OKTA_CLIENT_CLIENTID"`
 			Scopes            []string `yaml:"scopes" envconfig:"OKTA_CLIENT_SCOPES"`
 			PrivateKey        string   `yaml:"privateKey" envconfig:"OKTA_CLIENT_PRIVATEKEY"`
-                        PrivateKeyId      string   `yaml:"privateKeyId" envconfig:"OKTA_CLIENT_PRIVATEKEYID"`
+			PrivateKeyId      string   `yaml:"privateKeyId" envconfig:"OKTA_CLIENT_PRIVATEKEYID"`
 		} `yaml:"client"`
 		Testing struct {
 			DisableHttpsCheck bool `yaml:"disableHttpsCheck" envconfig:"OKTA_TESTING_DISABLE_HTTPS_CHECK"`
@@ -211,9 +211,9 @@ func WithPrivateKey(privateKey string) ConfigSetter {
 }
 
 func WithPrivateKeyId(privateKeyId string) ConfigSetter {
-        return func(c *config) {
-                c.Okta.Client.PrivateKeyId = privateKeyId
-        }
+	return func(c *config) {
+		c.Okta.Client.PrivateKeyId = privateKeyId
+	}
 }
 
 func WithPrivateKeySigner(signer jose.Signer) ConfigSetter {

--- a/okta/group.go
+++ b/okta/group.go
@@ -322,7 +322,6 @@ func (m *GroupResource) ListAssignedApplicationsForGroup(ctx context.Context, gr
 		apps[i] = &application[i]
 	}
 	return apps, resp, nil
-
 }
 
 func (m *GroupResource) ListGroupAssignedRoles(ctx context.Context, groupId string, qp *query.Params) ([]*Role, *Response, error) {

--- a/okta/inlineHookPayload.go
+++ b/okta/inlineHookPayload.go
@@ -18,5 +18,4 @@
 
 package okta
 
-type InlineHookPayload struct {
-}
+type InlineHookPayload struct{}

--- a/okta/orgSetting.go
+++ b/okta/orgSetting.go
@@ -191,7 +191,6 @@ func (m *OrgSettingResource) UpdateOrgLogo(ctx context.Context, file string) (*R
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	fw, err := writer.CreateFormFile("file", file)
-
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +201,6 @@ func (m *OrgSettingResource) UpdateOrgLogo(ctx context.Context, file string) (*R
 	_ = writer.Close()
 
 	req, err := rq.WithAccept("application/json").WithContentType(writer.FormDataContentType()).NewRequest("POST", url, body)
-
 	if err != nil {
 		return nil, err
 	}

--- a/okta/policy.go
+++ b/okta/policy.go
@@ -145,7 +145,6 @@ func (m *PolicyResource) ListPolicies(ctx context.Context, qp *query.Params) ([]
 		policies[i] = &policy[i]
 	}
 	return policies, resp, nil
-
 }
 
 // Creates a policy.

--- a/okta/query/query.go
+++ b/okta/query/query.go
@@ -77,26 +77,31 @@ func WithQ(queryQ string) ParamOptions {
 		p.Q = queryQ
 	}
 }
+
 func WithAfter(queryAfter string) ParamOptions {
 	return func(p *Params) {
 		p.After = queryAfter
 	}
 }
+
 func WithLimit(queryLimit int64) ParamOptions {
 	return func(p *Params) {
 		p.Limit = queryLimit
 	}
 }
+
 func WithFilter(queryFilter string) ParamOptions {
 	return func(p *Params) {
 		p.Filter = queryFilter
 	}
 }
+
 func WithExpand(queryExpand string) ParamOptions {
 	return func(p *Params) {
 		p.Expand = queryExpand
 	}
 }
+
 func WithIncludeNonDeleted(queryIncludeNonDeleted bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -104,6 +109,7 @@ func WithIncludeNonDeleted(queryIncludeNonDeleted bool) ParamOptions {
 		p.IncludeNonDeleted = b
 	}
 }
+
 func WithActivate(queryActivate bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -111,21 +117,25 @@ func WithActivate(queryActivate bool) ParamOptions {
 		p.Activate = b
 	}
 }
+
 func WithValidityYears(queryValidityYears int64) ParamOptions {
 	return func(p *Params) {
 		p.ValidityYears = queryValidityYears
 	}
 }
+
 func WithTargetAid(queryTargetAid string) ParamOptions {
 	return func(p *Params) {
 		p.TargetAid = queryTargetAid
 	}
 }
+
 func WithQueryScope(queryQueryScope string) ParamOptions {
 	return func(p *Params) {
 		p.QueryScope = queryQueryScope
 	}
 }
+
 func WithSendEmail(querySendEmail bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -133,21 +143,25 @@ func WithSendEmail(querySendEmail bool) ParamOptions {
 		p.SendEmail = b
 	}
 }
+
 func WithCursor(queryCursor string) ParamOptions {
 	return func(p *Params) {
 		p.Cursor = queryCursor
 	}
 }
+
 func WithMode(queryMode string) ParamOptions {
 	return func(p *Params) {
 		p.Mode = queryMode
 	}
 }
+
 func WithSearch(querySearch string) ParamOptions {
 	return func(p *Params) {
 		p.Search = querySearch
 	}
 }
+
 func WithRemoveUsers(queryRemoveUsers bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -155,6 +169,7 @@ func WithRemoveUsers(queryRemoveUsers bool) ParamOptions {
 		p.RemoveUsers = b
 	}
 }
+
 func WithDisableNotifications(queryDisableNotifications bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -162,66 +177,79 @@ func WithDisableNotifications(queryDisableNotifications bool) ParamOptions {
 		p.DisableNotifications = b
 	}
 }
+
 func WithType(queryType string) ParamOptions {
 	return func(p *Params) {
 		p.Type = queryType
 	}
 }
+
 func WithTargetIdpId(queryTargetIdpId string) ParamOptions {
 	return func(p *Params) {
 		p.TargetIdpId = queryTargetIdpId
 	}
 }
+
 func WithSince(querySince string) ParamOptions {
 	return func(p *Params) {
 		p.Since = querySince
 	}
 }
+
 func WithUntil(queryUntil string) ParamOptions {
 	return func(p *Params) {
 		p.Until = queryUntil
 	}
 }
+
 func WithSortOrder(querySortOrder string) ParamOptions {
 	return func(p *Params) {
 		p.SortOrder = querySortOrder
 	}
 }
+
 func WithSourceId(querySourceId string) ParamOptions {
 	return func(p *Params) {
 		p.SourceId = querySourceId
 	}
 }
+
 func WithTargetId(queryTargetId string) ParamOptions {
 	return func(p *Params) {
 		p.TargetId = queryTargetId
 	}
 }
+
 func WithStatus(queryStatus string) ParamOptions {
 	return func(p *Params) {
 		p.Status = queryStatus
 	}
 }
+
 func WithTemplateType(queryTemplateType string) ParamOptions {
 	return func(p *Params) {
 		p.TemplateType = queryTemplateType
 	}
 }
+
 func WithSortBy(querySortBy string) ParamOptions {
 	return func(p *Params) {
 		p.SortBy = querySortBy
 	}
 }
+
 func WithProvider(queryProvider interface{}) ParamOptions {
 	return func(p *Params) {
 		p.Provider = queryProvider
 	}
 }
+
 func WithNextLogin(queryNextLogin string) ParamOptions {
 	return func(p *Params) {
 		p.NextLogin = queryNextLogin
 	}
 }
+
 func WithStrict(queryStrict bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -229,6 +257,7 @@ func WithStrict(queryStrict bool) ParamOptions {
 		p.Strict = b
 	}
 }
+
 func WithUpdatePhone(queryUpdatePhone bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)
@@ -236,21 +265,25 @@ func WithUpdatePhone(queryUpdatePhone bool) ParamOptions {
 		p.UpdatePhone = b
 	}
 }
+
 func WithTemplateId(queryTemplateId string) ParamOptions {
 	return func(p *Params) {
 		p.TemplateId = queryTemplateId
 	}
 }
+
 func WithTokenLifetimeSeconds(queryTokenLifetimeSeconds int64) ParamOptions {
 	return func(p *Params) {
 		p.TokenLifetimeSeconds = queryTokenLifetimeSeconds
 	}
 }
+
 func WithScopeId(queryScopeId string) ParamOptions {
 	return func(p *Params) {
 		p.ScopeId = queryScopeId
 	}
 }
+
 func WithOauthTokens(queryOauthTokens bool) ParamOptions {
 	return func(p *Params) {
 		b := new(bool)

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -142,7 +142,12 @@ func (re *RequestExecutor) NewRequest(method string, url string, body interface{
 					return nil, err
 				}
 
-				re.config.PrivateKeySigner, err = jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: parsedKey}, nil)
+                                var signerOptions *jose.SignerOptions
+                                if re.config.Okta.Client.PrivateKeyId != "" {
+                                        signerOptions = (&jose.SignerOptions{}).WithHeader("kid", re.config.Okta.Client.PrivateKeyId)
+                                }
+
+				re.config.PrivateKeySigner, err = jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: parsedKey}, signerOptions)
 				if err != nil {
 					return nil, err
 				}

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -142,10 +142,10 @@ func (re *RequestExecutor) NewRequest(method string, url string, body interface{
 					return nil, err
 				}
 
-                                var signerOptions *jose.SignerOptions
-                                if re.config.Okta.Client.PrivateKeyId != "" {
-                                        signerOptions = (&jose.SignerOptions{}).WithHeader("kid", re.config.Okta.Client.PrivateKeyId)
-                                }
+				var signerOptions *jose.SignerOptions
+				if re.config.Okta.Client.PrivateKeyId != "" {
+					signerOptions = (&jose.SignerOptions{}).WithHeader("kid", re.config.Okta.Client.PrivateKeyId)
+				}
 
 				re.config.PrivateKeySigner, err = jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: parsedKey}, signerOptions)
 				if err != nil {

--- a/okta/userFactor.go
+++ b/okta/userFactor.go
@@ -94,7 +94,6 @@ func (m *UserFactorResource) ListFactors(ctx context.Context, userId string) ([]
 		factors[i] = &userFactor[i]
 	}
 	return factors, resp, nil
-
 }
 
 // Enrolls a user with a supported factor.
@@ -144,7 +143,6 @@ func (m *UserFactorResource) ListSupportedFactors(ctx context.Context, userId st
 		factors[i] = &userFactor[i]
 	}
 	return factors, resp, nil
-
 }
 
 // Enumerates all available security questions for a user&#x27;s &#x60;question&#x60; factor

--- a/tests/integration/group_test.go
+++ b/tests/integration/group_test.go
@@ -224,7 +224,7 @@ func TestGroupRuleOperations(t *testing.T) {
 	require.NoError(t, err)
 	// Create a user with credentials, activated by default → POST /api/v1/users?activate=true
 	p := &okta.PasswordCredential{
-		Value: randomString(10),
+		Value: testPassword(10),
 	}
 	uc := &okta.UserCredentials{
 		Password: p,

--- a/tests/integration/group_test.go
+++ b/tests/integration/group_test.go
@@ -19,10 +19,12 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/query"
 	"github.com/okta/okta-sdk-golang/v2/tests"
@@ -285,20 +287,31 @@ func TestGroupRuleOperations(t *testing.T) {
 	_, err = client.Group.ActivateGroupRule(ctx, groupRule.Id)
 	require.NoError(t, err, "Should not error when activating rule")
 
-	time.Sleep(30 * time.Second)
-	users, _, _ := client.Group.ListGroupUsers(ctx, group.Id, nil)
-	found := false
-	for _, tmpuser := range users {
-		if tmpuser.Id == user.Id {
-			found = true
+	users := []*okta.User{}
+
+	// Use a backoff to check the user is in the group as there can be eventual
+	// consistency issues in adding users to groups.
+	operation := func() error {
+		users, _, err = client.Group.ListGroupUsers(ctx, group.Id, nil)
+		if err != nil {
+			return err
 		}
+		for _, tmpuser := range users {
+			if tmpuser.Id == user.Id {
+				return nil
+			}
+		}
+		return fmt.Errorf("returning error so backoff continues to looking for user being added")
 	}
-	assert.True(t, found, "Group rule execution did not happen")
+	bOff := backoff.NewExponentialBackOff()
+	bOff.MaxElapsedTime = 30 * time.Second
+	err = backoff.Retry(operation, bOff)
+	require.NoError(t, err, "Inspecting group for user addition had an issue.")
 
 	// List the group rules and validate the above rule is present → POST /api/v1/groups/rules
 	groupRules, _, err := client.Group.ListGroupRules(ctx, nil)
 	require.NoError(t, err, "Error should not happen when listing rules")
-	found = false
+	found := false
 	for _, tmpRules := range groupRules {
 		if tmpRules.Id == groupRule.Id {
 			found = true
@@ -336,15 +349,24 @@ func TestGroupRuleOperations(t *testing.T) {
 	// Activate the updated rule and verify that the user is removed from the group →  POST /api/v1/groups/rules/{{ruleId}}/lifecycle/activate
 	_, err = client.Group.ActivateGroupRule(ctx, newGroupRule.Id)
 	require.NoError(t, err, "Should not error when activating the group rule")
-	time.Sleep(5 * time.Second)
-	users, _, _ = client.Group.ListGroupUsers(ctx, group.Id, nil)
-	found = false
-	for _, tmpuser := range users {
-		if tmpuser.Id == user.Id {
-			found = true
+
+	bOff.Reset()
+	// Use a backoff to check the user has been removed from the group as there
+	// can be eventual consistency issues in removing users from groups.
+	operation = func() error {
+		users, _, err = client.Group.ListGroupUsers(ctx, group.Id, nil)
+		if err != nil {
+			return err
 		}
+		for _, tmpuser := range users {
+			if tmpuser.Id == user.Id {
+				return fmt.Errorf("returning error so backoff continues user still listed in group")
+			}
+		}
+		return nil
 	}
-	assert.False(t, found, "Group rule execution did not happen to remove user")
+	err = backoff.Retry(operation, bOff)
+	require.NoError(t, err, "Inspecting group for user removal had an issue.")
 
 	// Deactivate the user, group and group rule → POST /api/v1/users/{{userId}}/lifecycle/deactivate
 	_, err = client.Group.DeactivateGroupRule(ctx, newGroupRule.Id)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -125,27 +125,36 @@ func ensureUserDelete(ctx context.Context, client *okta.Client, id, status strin
 }
 
 const (
-	charSetAlpha = "abcdefghijklmnopqrstuvwxyz"
-	testPrefix   = "SDK_TEST_"
+	charSetAlphaUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	charSetAlphaLower = "abcdefghijklmnopqrstuvwxyz"
+	charSetNumeric    = "0123456789"
+	charSetAlpha      = charSetAlphaLower + charSetAlphaUpper + charSetNumeric
+	testPrefix        = "SDK_TEST_"
 )
 
 func randomEmail() string {
 	return randomTestString() + "@example.com"
 }
 
-// randStringFromCharSet generates a random string by selecting characters from
-// the charset provided
+// randStringFromCharSet generates a random string of 15 lower case letters
 func randomTestString() string {
 	result := make([]byte, 15)
 	for i := 0; i < 15; i++ {
-		result[i] = charSetAlpha[rand.Intn(len(charSetAlpha))]
+		result[i] = charSetAlphaLower[rand.Intn(len(charSetAlphaLower))]
 	}
 	return testPrefix + string(result)
 }
 
-func randomString(length int) string {
+// testPassword generates a random string of at least 4 characters in length
+func testPassword(length int) string {
+	if length < 5 {
+		length = 4
+	}
 	result := make([]byte, length)
-	for i := 0; i < length; i++ {
+	result[0] = charSetAlphaLower[rand.Intn(len(charSetAlphaLower))]
+	result[1] = charSetAlphaUpper[rand.Intn(len(charSetAlphaUpper))]
+	result[2] = charSetNumeric[rand.Intn(len(charSetNumeric))]
+	for i := 2; i < length; i++ {
 		result[i] = charSetAlpha[rand.Intn(len(charSetAlpha))]
 	}
 	return string(result)


### PR DESCRIPTION
- Cherry picking in @emanor-okta's #295 "Adds ability to specify JWT kid header" so we can run this change in CI
- mvdan.cc/gofumpt was updated, formatting changes from `make fmt`
- Updated password generator used in the tests as a policy changed in the test org
- `TestGroupRuleOperations` integration test was flapping and slow so it was wrapped it in a backoff to remove 35 seconds of hardcoded sleep time
