### PR TITLE
OAuth token caching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@ language: go
 
 jobs:
   include:
-    - stage: test_go_1.17
-      go: 1.17.x
+    - stage: test_go_1.19
+      go: 1.19.x
       script:
         - go mod download
         - make test
-    - stage: test_go_tip
-      go: tip
-      script:
-        - go mod download
-        - make test
+
+    # go tip build is broken upstream on Travis
+    # - stage: test_go_tip
+    #   go: tip
+    #   script:
+    #     - go mod download
+    #     - make test

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ facility to clear the request cache. See [Refreshing Cache for Specific
 Call](#refreshing-cache-for-specific-call). To completely disable the request
 memory cache configure the client with `WithCache(false)`.
 
+NOTE: Regardless of cache manager, Access Tokens from OAuth requests are always
+cached.
+
 ## Connection Retry / Rate Limiting
 
 By default this SDK retries requests that are returned with a 429 exception. To
@@ -908,6 +911,9 @@ Okta allows you to interact with Okta APIs using scoped OAuth 2.0 access
 tokens. Each access token enables the bearer to perform specific actions on
 specific Okta endpoints, with that ability controlled by which scopes the
 access token contains.
+
+Access Tokens are always cached and respect the `expires_in` value of an access
+token response.
 
 This SDK supports this feature only for service-to-service applications. Check
 out [our

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/okta/okta-sdk-golang/v2
 
-go 1.17
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -65,7 +65,7 @@ type ClientAssertionClaims struct {
 
 type RequestAccessToken struct {
 	TokenType   string `json:"token_type,omitempty"`
-	ExpireIn    int    `json:"expire_in,omitempty"`
+	ExpiresIn   int    `json:"expires_in,omitempty"`
 	AccessToken string `json:"access_token,omitempty"`
 	Scope       string `json:"scope,omitempty"`
 }

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -329,7 +329,9 @@ func (re *RequestExecutor) doWithRetries(ctx context.Context, req *http.Request)
 		err  error
 	)
 	if re.config.Okta.Client.RequestTimeout > 0 {
-		ctx, _ = context.WithTimeout(ctx, time.Second*time.Duration(re.config.Okta.Client.RequestTimeout))
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(re.config.Okta.Client.RequestTimeout))
+		defer cancel()
 	}
 	bOff := &oktaBackoff{
 		ctx:        ctx,

--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -100,11 +100,11 @@ func NewRequestExecutor(httpClient *http.Client, cache cache.Cache, config *conf
 func (re *RequestExecutor) NewRequest(method string, url string, body interface{}) (*http.Request, error) {
 	var buff io.ReadWriter
 	if body != nil {
-		switch body.(type) {
+		switch v := body.(type) {
 		case []byte:
-			buff = bytes.NewBuffer(body.([]byte))
+			buff = bytes.NewBuffer(v)
 		case *bytes.Buffer:
-			buff = body.(*bytes.Buffer)
+			buff = v
 		default:
 			buff = new(bytes.Buffer)
 			encoder := json.NewEncoder(buff)

--- a/tests/unit/cache_test.go
+++ b/tests/unit/cache_test.go
@@ -125,14 +125,13 @@ func Test_cache_can_be_cleared(t *testing.T) {
 }
 
 // TestOAuthTokensAlwaysCached demonstrates oauth tokens are always cached even
-// when the client is initialized with a noop cache manager.
+// when the client has request caching disabled.
 func TestOAuthTokensAlwaysCached(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	cacheMgr := cache.NewNoOpCache()
 	ctx, client, err := tests.NewClient(context.TODO(),
-		okta.WithCacheManager(cacheMgr),
+		okta.WithCache(false),
 		okta.WithOrgUrl("https://testing.oktapreview.com"),
 		okta.WithAuthorizationMode("PrivateKey"),
 		okta.WithClientId("abc"),

--- a/tests/unit/cache_test.go
+++ b/tests/unit/cache_test.go
@@ -17,15 +17,22 @@
 package unit
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
+	"github.com/okta/okta-sdk-golang/v2/okta"
 	"github.com/okta/okta-sdk-golang/v2/okta/cache"
+	"github.com/okta/okta-sdk-golang/v2/okta/query"
+	"github.com/okta/okta-sdk-golang/v2/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_cache_key_can_be_created_from_request_object(t *testing.T) {
@@ -115,4 +122,86 @@ func Test_cache_can_be_cleared(t *testing.T) {
 
 	found = myCache.Has(cacheKey)
 	assert.False(t, found, "cache was not cleared")
+}
+
+// TestOAuthTokensAlwaysCached demonstrates oauth tokens are always cached even
+// when the client is initialized with a noop cache manager.
+func TestOAuthTokensAlwaysCached(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	cacheMgr := cache.NewNoOpCache()
+	ctx, client, err := tests.NewClient(context.TODO(),
+		okta.WithCacheManager(cacheMgr),
+		okta.WithOrgUrl("https://testing.oktapreview.com"),
+		okta.WithAuthorizationMode("PrivateKey"),
+		okta.WithClientId("abc"),
+		okta.WithPrivateKey(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
+KUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm
+o3qGy0t6z09AIJtH+5OeRV1be+N4cDYJKffGzDa88vQENZiRm0GRq6a+HPGQMd2k
+TQIhAKMSvzIBnni7ot/OSie2TmJLY4SwTQAevXysE2RbFDYdAiEBCUEaRQnMnbp7
+9mxDXDf6AU0cN/RPBjb9qSHDcWZHGzUCIG2Es59z8ugGrDY+pxLQnwfotadxd+Uy
+v/Ow5T0q5gIJAiEAyS4RaI9YG8EWx/2w0T67ZUVAw8eOMB6BIUg0Xcu+3okCIBOs
+/5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
+-----END RSA PRIVATE KEY-----
+		`),
+		okta.WithScopes(([]string{"okta.apps.read"})))
+	require.NoError(t, err)
+
+	accessToken := okta.RequestAccessToken{
+		TokenType:   "Bearer",
+		ExpiresIn:   3600,
+		AccessToken: "xyz",
+		Scope:       "okta.apps.read",
+	}
+	httpmockTokenURLRegex := `=~^https://testing\.oktapreview\.com/oauth2/v1/token\?client_assertion=.*\z`
+	jsonResp, err := httpmock.NewJsonResponder(200, accessToken)
+	require.NoError(t, err)
+	httpmock.RegisterResponder("POST", httpmockTokenURLRegex, jsonResp)
+
+	adminConsole := []okta.Application{{
+		Id:     "abc123",
+		Name:   "saasure",
+		Label:  "Okta Admin Console",
+		Status: "ACTIVE",
+	}}
+	jsonResp, err = httpmock.NewJsonResponder(200, adminConsole)
+	require.NoError(t, err)
+	httpmockAdminConsoleRegex := `=~^https://testing\.oktapreview\.com/api/v1/apps?.*q\=Okta\+Admin\+Console.*\z`
+	httpmock.RegisterResponder("GET", httpmockAdminConsoleRegex, jsonResp)
+
+	dashboard := []okta.Application{{
+		Id:     "def456",
+		Name:   "okta_enduser",
+		Label:  "Okta Dashboard",
+		Status: "ACTIVE",
+	}}
+	jsonResp, err = httpmock.NewJsonResponder(200, dashboard)
+	require.NoError(t, err)
+	httpmockDashboardRegex := `=~^https://testing\.oktapreview\.com/api/v1/apps?.*q\=Okta\+Dashboard.*\z`
+	httpmock.RegisterResponder("GET", httpmockDashboardRegex, jsonResp)
+
+	_, _, err = client.Application.ListApplications(ctx, &query.Params{Limit: 1, Filter: "status eq ACTIVE", Q: "Okta Admin Console"})
+	require.NoError(t, err)
+	_, _, err = client.Application.ListApplications(ctx, &query.Params{Limit: 1, Filter: "status eq ACTIVE", Q: "Okta Admin Console"})
+	require.NoError(t, err)
+
+	_, _, err = client.Application.ListApplications(ctx, &query.Params{Limit: 1, Filter: "status eq ACTIVE", Q: "Okta Dashboard"})
+	require.NoError(t, err)
+	_, _, err = client.Application.ListApplications(ctx, &query.Params{Limit: 1, Filter: "status eq ACTIVE", Q: "Okta Dashboard"})
+	require.NoError(t, err)
+
+	info := httpmock.GetCallCountInfo()
+	totalCalls := httpmock.GetTotalCallCount()
+
+	assert.Equal(t, 5, totalCalls, fmt.Sprintf("there should only be 5 API calls in this test but there were %d calls", totalCalls))
+
+	// Tokens from requests should be cached.
+	require.True(t, info[fmt.Sprintf("POST %s", httpmockTokenURLRegex)] == 1, "tokens endpoint should only be called once")
+
+	// But all other requests should not be cached.
+	require.True(t, info[fmt.Sprintf("GET %s", httpmockAdminConsoleRegex)] == 2)
+	require.True(t, info[fmt.Sprintf("GET %s", httpmockDashboardRegex)] == 2)
 }


### PR DESCRIPTION
## Summary
OAuth tokens are cached regardless of what request cache manager is utilized on the client.

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #
Benefit Okta Terraform Provider (Okta internal ref https://oktainc.atlassian.net/browse/OKTA-519225)

## Type of PR
- [ ] Bug Fix (non-breaking fixes to existing functionality)
- [x] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
- [x] My PR added tests to demonstrate implemented behavior
- [ ] My PR required test updates

Go Version: 1.19
Os Version:
OpenAPI Spec Version: 2.13.1


## Signoff
- [ ] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files
