### PR TITLE
Try to read .okta.yaml config file from working directory

### DIFF
--- a/.generator/templates/configuration.mustache
+++ b/.generator/templates/configuration.mustache
@@ -250,6 +250,7 @@ func NewConfiguration(conf ...ConfigSetter) *Configuration {
 	cfg.Okta.Client.AuthorizationMode = "SSWS"
 
     cfg = readConfigFromSystem(*cfg)
+	cfg = readConfigFromWorkingDirectory(*cfg)
 	cfg = readConfigFromApplication(*cfg)
 	cfg = readConfigFromEnvironment(*cfg)
 
@@ -302,6 +303,14 @@ func readConfigFromSystem(c Configuration) *Configuration {
 		return &c
 	}
 	conf, err := readConfigFromFile(currUser.HomeDir+"/.okta/okta.yaml", c)
+	if err != nil {
+		return &c
+	}
+	return conf
+}
+
+func readConfigFromWorkingDirectory(c config) *config {
+	conf, err := readConfigFromFile(".okta.yaml", c)
 	if err != nil {
 		return &c
 	}

--- a/README.md
+++ b/README.md
@@ -770,6 +770,7 @@ This library looks for configuration in the following sources:
 
 0. An `okta.yaml` file in a `.okta` folder in the current user's home directory
    (`~/.okta/okta.yaml` or `%userprofile\.okta\okta.yaml`)
+0. A `.okta.yaml` file in the current working directory
 0. A `.okta.yaml` file in the application or project's root directory
 0. Environment variables
 0. Configuration explicitly passed to the constructor (see the example in

--- a/okta/okta.go
+++ b/okta/okta.go
@@ -77,6 +77,7 @@ func NewClient(ctx context.Context, conf ...ConfigSetter) (context.Context, *Cli
 
 	setConfigDefaults(config)
 	config = readConfigFromSystem(*config)
+	config = readConfigFromWorkingDirectory(*config)
 	config = readConfigFromApplication(*config)
 	config = readConfigFromEnvironment(*config)
 
@@ -214,6 +215,14 @@ func readConfigFromSystem(c config) *config {
 		return &c
 	}
 	conf, err := readConfigFromFile(currUser.HomeDir+"/.okta/okta.yaml", c)
+	if err != nil {
+		return &c
+	}
+	return conf
+}
+
+func readConfigFromWorkingDirectory(c config) *config {
+	conf, err := readConfigFromFile(".okta.yaml", c)
 	if err != nil {
 		return &c
 	}

--- a/openapi/generator/templates/okta.go.hbs
+++ b/openapi/generator/templates/okta.go.hbs
@@ -36,6 +36,7 @@ func NewClient(ctx context.Context, conf ...ConfigSetter) (context.Context, *Cli
 
 	setConfigDefaults(config)
 	config = readConfigFromSystem(*config)
+	config = readConfigFromWorkingDirectory(*config)
 	config = readConfigFromApplication(*config)
 	config = readConfigFromEnvironment(*config)
 
@@ -94,7 +95,7 @@ func (c *Client) SetConfig(conf ...ConfigSetter) (err error) {
 		return
 	}
 	c.config = config
-	return 
+	return
 }
 
 // GetRequestExecutor returns underlying request executor
@@ -148,6 +149,14 @@ func readConfigFromSystem(c config) *config {
 		return &c
 	}
 	conf, err := readConfigFromFile(currUser.HomeDir+"/.okta/okta.yaml", c)
+	if err != nil {
+		return &c
+	}
+	return conf
+}
+
+func readConfigFromWorkingDirectory(c config) *config {
+	conf, err := readConfigFromFile(".okta.yaml", c)
 	if err != nil {
 		return &c
 	}


### PR DESCRIPTION
## Summary
The documentation makes it sound like the expected behavior regarding the `.okta.yaml` file is to read it from the applications directory. This, however, tries to read the config file from the shared library when not building statically. Instead of patching this behavior, in case somebody depends on it, I have added another check to try to load the config file from the applications working directory.

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #349

## Type of PR
- [X] Bug Fix (non-breaking fixes to existing functionality)
- [X] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Signoff
- [X] I have submitted a CLA for this PR
- [X] Each commit message explains what the commit does
- [X] I have updated documentation to explain what my PR does
- [X] My code is covered by tests if required
- [X] I ran `make fmt` on my code
- [X] I did not edit any automatically generated files
