### PR TITLE
return response even upon error

### DIFF
--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -697,8 +697,7 @@ func buildResponse(resp *http.Response, re *RequestExecutor, v interface{}) (*Re
 	if err == io.EOF {
 		err = nil
 	}
-	if err != nil {
-		return nil, err
-	}
+	// return the response even if there was an error decoding the body
+	// so the user can inspect the response headers and status code
 	return response, nil
 }


### PR DESCRIPTION
The decoder might fail on the given `v` object, but the returned Golang error is not indicative enough. Return the response to let the user inspect it to make things easier.

<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
The SDK functions might fail upon a malformed JSON returned from the server. The internal `buildResponse` function tries to unmarshal the response. If it fails, it returns the native Golang error without the response from the server. 
The native error is not informative, so the response is crucial to determine the root cause, especially in a production environment where debugging is not possible.
To solve that, the `buildResponse` function returns the response from the server (instead of `nil`) even when there is an error. 
This should not break any existing functionality and usage of the SDK.

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version: 1.22.0
Os Version: macOS Sonoma 14.2.1
OpenAPI Spec Version:


## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files
