### PR TITLE
fix: Use `map[string]interface{}` for `AppUser.Profile` and `ApplicationGroupAssignment.Profile`

### DIFF
--- a/.generator/okta-management-APIs-oasv3-enum-inheritance.yaml
+++ b/.generator/okta-management-APIs-oasv3-enum-inheritance.yaml
@@ -28160,9 +28160,6 @@ components:
         SSO apps typically don't support app user profiles, while apps with user provisioning features have app-specific profiles.
         Properties that are visible in the Admin Console for an app assignment can also be assigned through the API.
         Some properties are reference properties that are imported from the target app and can't be configured.
-      additionalProperties:
-        type: object
-        properties: {}
       type: object
     AppUserStatus:
       description: Status of an App User
@@ -28390,9 +28387,6 @@ components:
           type: integer
         profile:
           type: object
-          additionalProperties:
-            type: object
-            properties: {}
         _embedded:
           type: object
           additionalProperties:

--- a/.generator/okta-management-APIs-oasv3-noEnums-inheritance.yaml
+++ b/.generator/okta-management-APIs-oasv3-noEnums-inheritance.yaml
@@ -28160,9 +28160,6 @@ components:
         SSO apps typically don't support app user profiles, while apps with user provisioning features have app-specific profiles.
         Properties that are visible in the Admin Console for an app assignment can also be assigned through the API.
         Some properties are reference properties that are imported from the target app and can't be configured.
-      additionalProperties:
-        type: object
-        properties: {}
       type: object
     AppUserStatus:
       description: Status of an App User
@@ -28390,9 +28387,6 @@ components:
           type: integer
         profile:
           type: object
-          additionalProperties:
-            type: object
-            properties: {}
         _embedded:
           type: object
           additionalProperties:

--- a/okta/docs/AppUser.md
+++ b/okta/docs/AppUser.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **LastSync** | Pointer to **time.Time** | Timestamp of the last synchronization operation. This value is only updated for apps with the &#x60;IMPORT_PROFILE_UPDATES&#x60; or &#x60;PUSH PROFILE_UPDATES&#x60; feature. | [optional] [readonly] 
 **LastUpdated** | [**time.Time**](time.Time.md) |  | 
 **PasswordChanged** | Pointer to **NullableTime** | Timestamp when the App User password was last changed | [optional] [readonly] 
-**Profile** | Pointer to **map[string]map[string]interface{}** | App user profiles are app-specific and can be customized by the Profile Editor in the Admin Console. SSO apps typically don&#39;t support app user profiles, while apps with user provisioning features have app-specific profiles. Properties that are visible in the Admin Console for an app assignment can also be assigned through the API. Some properties are reference properties that are imported from the target app and can&#39;t be configured. | [optional] 
+**Profile** | Pointer to **map[string]interface{}** | App user profiles are app-specific and can be customized by the Profile Editor in the Admin Console. SSO apps typically don&#39;t support app user profiles, while apps with user provisioning features have app-specific profiles. Properties that are visible in the Admin Console for an app assignment can also be assigned through the API. Some properties are reference properties that are imported from the target app and can&#39;t be configured. | [optional] 
 **Scope** | **string** | Toggles the assignment between user or group scope | 
 **Status** | **string** | Status of an App User | [readonly] 
 **StatusChanged** | **time.Time** | Timestamp when the App User status was last changed | [readonly] 
@@ -215,20 +215,20 @@ HasPasswordChanged returns a boolean if a field has been set.
 UnsetPasswordChanged ensures that no value is present for PasswordChanged, not even an explicit nil
 ### GetProfile
 
-`func (o *AppUser) GetProfile() map[string]map[string]interface{}`
+`func (o *AppUser) GetProfile() map[string]interface{}`
 
 GetProfile returns the Profile field if non-nil, zero value otherwise.
 
 ### GetProfileOk
 
-`func (o *AppUser) GetProfileOk() (*map[string]map[string]interface{}, bool)`
+`func (o *AppUser) GetProfileOk() (*map[string]interface{}, bool)`
 
 GetProfileOk returns a tuple with the Profile field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetProfile
 
-`func (o *AppUser) SetProfile(v map[string]map[string]interface{})`
+`func (o *AppUser) SetProfile(v map[string]interface{})`
 
 SetProfile sets Profile field to given value.
 

--- a/okta/docs/ApplicationGroupAssignment.md
+++ b/okta/docs/ApplicationGroupAssignment.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **Id** | Pointer to **string** |  | [optional] [readonly] 
 **LastUpdated** | Pointer to **time.Time** |  | [optional] [readonly] 
 **Priority** | Pointer to **int32** |  | [optional] 
-**Profile** | Pointer to **map[string]map[string]interface{}** |  | [optional] 
+**Profile** | Pointer to **map[string]interface{}** |  | [optional] 
 **Embedded** | Pointer to **map[string]map[string]interface{}** |  | [optional] [readonly] 
 **Links** | Pointer to [**LinksSelf**](LinksSelf.md) |  | [optional] 
 
@@ -107,20 +107,20 @@ HasPriority returns a boolean if a field has been set.
 
 ### GetProfile
 
-`func (o *ApplicationGroupAssignment) GetProfile() map[string]map[string]interface{}`
+`func (o *ApplicationGroupAssignment) GetProfile() map[string]interface{}`
 
 GetProfile returns the Profile field if non-nil, zero value otherwise.
 
 ### GetProfileOk
 
-`func (o *ApplicationGroupAssignment) GetProfileOk() (*map[string]map[string]interface{}, bool)`
+`func (o *ApplicationGroupAssignment) GetProfileOk() (*map[string]interface{}, bool)`
 
 GetProfileOk returns a tuple with the Profile field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetProfile
 
-`func (o *ApplicationGroupAssignment) SetProfile(v map[string]map[string]interface{})`
+`func (o *ApplicationGroupAssignment) SetProfile(v map[string]interface{})`
 
 SetProfile sets Profile field to given value.
 

--- a/okta/model_app_user.go
+++ b/okta/model_app_user.go
@@ -43,7 +43,7 @@ type AppUser struct {
 	// Timestamp when the App User password was last changed
 	PasswordChanged NullableTime `json:"passwordChanged,omitempty"`
 	// App user profiles are app-specific and can be customized by the Profile Editor in the Admin Console. SSO apps typically don't support app user profiles, while apps with user provisioning features have app-specific profiles. Properties that are visible in the Admin Console for an app assignment can also be assigned through the API. Some properties are reference properties that are imported from the target app and can't be configured.
-	Profile map[string]map[string]interface{} `json:"profile,omitempty"`
+	Profile map[string]interface{} `json:"profile,omitempty"`
 	// Toggles the assignment between user or group scope
 	Scope string `json:"scope"`
 	// Status of an App User
@@ -303,9 +303,9 @@ func (o *AppUser) UnsetPasswordChanged() {
 }
 
 // GetProfile returns the Profile field value if set, zero value otherwise.
-func (o *AppUser) GetProfile() map[string]map[string]interface{} {
+func (o *AppUser) GetProfile() map[string]interface{} {
 	if o == nil || o.Profile == nil {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.Profile
@@ -313,7 +313,7 @@ func (o *AppUser) GetProfile() map[string]map[string]interface{} {
 
 // GetProfileOk returns a tuple with the Profile field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AppUser) GetProfileOk() (map[string]map[string]interface{}, bool) {
+func (o *AppUser) GetProfileOk() (map[string]interface{}, bool) {
 	if o == nil || o.Profile == nil {
 		return nil, false
 	}
@@ -329,8 +329,8 @@ func (o *AppUser) HasProfile() bool {
 	return false
 }
 
-// SetProfile gets a reference to the given map[string]map[string]interface{} and assigns it to the Profile field.
-func (o *AppUser) SetProfile(v map[string]map[string]interface{}) {
+// SetProfile gets a reference to the given map[string]interface{} and assigns it to the Profile field.
+func (o *AppUser) SetProfile(v map[string]interface{}) {
 	o.Profile = v
 }
 

--- a/okta/model_application_group_assignment.go
+++ b/okta/model_application_group_assignment.go
@@ -34,7 +34,7 @@ type ApplicationGroupAssignment struct {
 	Id                   *string                           `json:"id,omitempty"`
 	LastUpdated          *time.Time                        `json:"lastUpdated,omitempty"`
 	Priority             *int32                            `json:"priority,omitempty"`
-	Profile              map[string]map[string]interface{} `json:"profile,omitempty"`
+	Profile              map[string]interface{}            `json:"profile,omitempty"`
 	Embedded             map[string]map[string]interface{} `json:"_embedded,omitempty"`
 	Links                *LinksSelf                        `json:"_links,omitempty"`
 	AdditionalProperties map[string]interface{}
@@ -156,9 +156,9 @@ func (o *ApplicationGroupAssignment) SetPriority(v int32) {
 }
 
 // GetProfile returns the Profile field value if set, zero value otherwise.
-func (o *ApplicationGroupAssignment) GetProfile() map[string]map[string]interface{} {
+func (o *ApplicationGroupAssignment) GetProfile() map[string]interface{} {
 	if o == nil || o.Profile == nil {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.Profile
@@ -166,7 +166,7 @@ func (o *ApplicationGroupAssignment) GetProfile() map[string]map[string]interfac
 
 // GetProfileOk returns a tuple with the Profile field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ApplicationGroupAssignment) GetProfileOk() (map[string]map[string]interface{}, bool) {
+func (o *ApplicationGroupAssignment) GetProfileOk() (map[string]interface{}, bool) {
 	if o == nil || o.Profile == nil {
 		return nil, false
 	}
@@ -182,8 +182,8 @@ func (o *ApplicationGroupAssignment) HasProfile() bool {
 	return false
 }
 
-// SetProfile gets a reference to the given map[string]map[string]interface{} and assigns it to the Profile field.
-func (o *ApplicationGroupAssignment) SetProfile(v map[string]map[string]interface{}) {
+// SetProfile gets a reference to the given map[string]interface{} and assigns it to the Profile field.
+func (o *ApplicationGroupAssignment) SetProfile(v map[string]interface{}) {
 	o.Profile = v
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
<!-- Be concise with your summery, but explain what changed -->

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #https://github.com/okta/okta-sdk-golang/issues/447

So what I did is remove the extra empty `additionalProperties` from the specs and re-ran `make v4-generate`. Not sure if there's a better way to do it.

The same problem exists in other fields as well (for example `ApplicationGroupAssignment.Embedded`) so it might be necessary do go over all `additionalProperties` in the specs and do the same, but wanted to get some feedback on the fix first

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [x] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version: `go version go1.22.1 darwin/arm64`
Os Version:
OpenAPI Spec Version: `23.4.0 Darwin Kernel Version 23.4.0`


## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files
