### PR TITLE
return error when access token request failed to avoid using empty tokens

### DIFF
--- a/okta/requestExecutor.go
+++ b/okta/requestExecutor.go
@@ -309,6 +309,13 @@ func getAccessTokenForPrivateKey(httpClient *http.Client, orgURL, clientAssertio
 	if err != nil {
 		return nil, err
 	}
+	if tokenResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"access token request failed, satus code: %d, response: %s",
+			tokenResponse.StatusCode,
+			respBody,
+		)
+	}
 	origResp := io.NopCloser(bytes.NewBuffer(respBody))
 	tokenResponse.Body = origResp
 	var accessToken *RequestAccessToken


### PR DESCRIPTION
return error when access token request failed to avoid using null access tokens

<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
<!-- Be concise with your summery, but explain what changed -->
Currently empty access tokens could be submitted to OKTA that leads to failed requests with uncertain reasons.
This happens when access token request completed with non-OK status code.

This PR fixes this behaviour by retuning an error with proper error descriptions instead of returning a null access token which is invalid obviously.

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes N/A

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version: 1.21.6
Os Version: MacOS 12.3 (Kernel Version 21.4.0)
OpenAPI Spec Version: 


## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files
