### PR TITLE
Fix codegen process to avoid manual intervention

### DIFF
--- a/.generator/templates/model_oneof.mustache
+++ b/.generator/templates/model_oneof.mustache
@@ -1,3 +1,4 @@
+
 //model_oneof.mustache
 // {{classname}} - {{{description}}}{{^description}}struct for {{{classname}}}{{/description}}
 type {{classname}} struct {
@@ -59,8 +60,8 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
         // try to unmarshal data into {{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}
         err = json.Unmarshal(data, &dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
         if err == nil {
-                json{{{.}}}, _ := json.Marshal(dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
-                if string(json{{{.}}}) == "{}" { // empty struct
+                json{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}, _ := json.Marshal(dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}})
+                if string(json{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}}) == "{}" { // empty struct
                         dst.{{#lambda.type-to-name}}{{{.}}}{{/lambda.type-to-name}} = nil
                 } else {
                         match++


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
While generating code using the existing mustache templates, produce non-compiling code. For Ex - 

![image](https://github.com/user-attachments/assets/ee2f1526-7f7d-4b9a-bef2-22c2aa5f4fc5)

Issue is if model name contains string ArrayOf then template is replacing it with []. See below code snippet from file okta/model_get_ssf_streams_200_response.go - 

```
        err = json.Unmarshal(data, &dst.ArrayOfStreamConfiguration)
        if err == nil {
                json[]StreamConfiguration, _ := json.Marshal(dst.ArrayOfStreamConfiguration)
                if string(json[]StreamConfiguration) == "{}" { // empty struct
                        dst.ArrayOfStreamConfiguration = nil
                } else {
                        match++
                }
        }
```

I changed the template model_oneof.mustache to modify the variable name. to make it work.

After the change - 

```
	err = json.Unmarshal(data, &dst.ArrayOfStreamConfiguration)
	if err == nil {
		jsonArrayOfStreamConfiguration, _ := json.Marshal(dst.ArrayOfStreamConfiguration)
		if string(jsonArrayOfStreamConfiguration) == "{}" { // empty struct
			dst.ArrayOfStreamConfiguration = nil
		} else {
			match++
		}
	} else {
		dst.ArrayOfStreamConfiguration = nil
	}
``` 
<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #

## Type of PR
<!-- Multiple selections are ok -->
- [ X] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version:
Os Version:
OpenAPI Spec Version:


## Signoff
- [ ] I have submitted a CLA for this PR
- [X ] Each commit message explains what the commit does
- [X] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [X] I ran `make fmt` on my code
- [X] I did not edit any automatically generated files
