### PR TITLE
feat: remove semgrep from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,15 +86,6 @@ workflows:
           name: execute-snyk
           context:
             - static-analysis
-  # See OKTA-624790
-  # See OKTA-729389
-  semgrep:
-    jobs:
-      - general-platform-helpers/job-semgrep-scan:
-          name: "Scan with Semgrep"
-          resource-class: "medium"
-          context:
-            - static-analysis
   "Malware Scanner":
     jobs:
       - reversing-labs:


### PR DESCRIPTION
The `Semgrep` scan can safely be removed from the `CircleCI` config.

https://oktawiki.atlassian.net/wiki/spaces/REX/pages/2784367385/Semgrep+Resource+Hub#Bacon-%2F-CircleCI-(automated-PR-generation-from-Terminus)