### PR TITLE
Release 5.0.6

### DIFF
--- a/.generator/config.yaml
+++ b/.generator/config.yaml
@@ -8,7 +8,7 @@ additionalProperties:
   enumClassPrefix: true
   generateInterfaces: true
   packageName: okta
-  packageVersion: 5.0.0
+  packageVersion: 5.0.6
   useOneOfDiscriminatorLookup: true
   disallowAdditionalPropertiesIfNotPresent: false
 files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Running changelog of releases since `2.0.0-rc.4`
 
+## v5.0.6
+- Add option to prevent 429 by enabling api throttling [#526](https://github.com/okta/okta-sdk-golang/pull/526). Thanks [@erezrokah](https://github.com/erezrokah) and [@aditya-okta](https://github.com/aditya-okta)
+
 ## v5.0.5
  - Fix the Go Documentation spam [#512](https://github.com/okta/okta-sdk-golang/pull/511). Thanks [@aditya-okta](https://github.com/aditya-okta)
  - Fix the support for signed nonce factor [#512](https://github.com/okta/okta-sdk-golang/pull/512). Thanks [@aditya-okta](https://github.com/aditya-okta)


### PR DESCRIPTION
## v5.0.6
- Add option to prevent 429 by enabling api throttling [#526](https://github.com/okta/okta-sdk-golang/pull/526). Thanks [@erezrokah](https://github.com/erezrokah) and [@aditya-okta](https://github.com/aditya-okta)