### PR TITLE
fix: only mark stale if maintainer has responded

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,23 +2,24 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "30 1 * * *"
+    - cron: "30 1 * * *"
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been marked stale because there has been no activity within the last 14 days. To keep this issue active, remove the `stale` label.'
-        stale-pr-message: 'This PR has been marked stale because there has been no activity within the last 28 days. To keep this PR active, remove the `stale` label.'
-        days-before-issue-stale: 14
-        days-before-pr-stale: 28
-        days-before-close: -1
-        exempt-issue-labels: 'no-stalebot'
-        exempt-pr-labels: 'no-stalebot'
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been marked stale because there has been no activity within the last 14 days. To keep this issue active, remove the `stale` label."
+          stale-pr-message: "This PR has been marked stale because there has been no activity within the last 28 days. To keep this PR active, remove the `stale` label."
+          days-before-issue-stale: 14
+          days-before-pr-stale: 28
+          days-before-close: -1
+          exempt-issue-labels: "no-stalebot"
+          exempt-pr-labels: "no-stalebot"
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          any-of-issue-labels: "waiting-response"
+          any-of-pr-labels: "waiting-response"


### PR DESCRIPTION
new gh issues or PRs shouldn't be marked as stale if they haven't been looked at by a maintainer

<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
update Stalebot to only mark issues as stale if they have a certain label
this avoids marking issues or PRs as stale if maintainers haven't had a chance to review them yet

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #

## Type of PR
<!-- Multiple selections are ok -->
- [ ] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [x] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version:
Os Version:
OpenAPI Spec Version:


## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I ran `make fmt` on my code
- [ ] I did not edit any automatically generated files
