### PR TITLE
fix(oauth): prevent panic when using JWK auth

### DIFF
--- a/okta/client.go
+++ b/okta/client.go
@@ -579,7 +579,7 @@ func (a *JWKAuth) Authorize(method, URL string) error {
 			return err
 		}
 
-		accessToken, nonce, dpopPrivateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, "", nil)
+		accessToken, nonce, dpopPrivateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, a.clientId, a.privateKeySigner)
 		if err != nil {
 			return err
 		}
@@ -941,9 +941,9 @@ func selectHeaderAccept(accepts []string) string {
 		return ""
 	}
 
-	//if contains(accepts, "application/json") {
+	// if contains(accepts, "application/json") {
 	//	return "application/json"
-	//}
+	// }
 
 	return strings.Join(accepts, ",")
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
When building the client assertion for JWK auth mode, `""` is being passed for the client ID and `nil` is being passed for the signer.

SDK config:
```go
okta.WithAuthorizationMode("JWK")
okta.WithJWK(jwkValue)
okta.WithEncryptionType("RSA")
```

Panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x103232ab8]

goroutine 1 [running]:
github.com/go-jose/go-jose/v3/jwt.(*signedBuilder).sign(0x1400016cd08)
	/Users/milas/dev/go/pkg/mod/github.com/go-jose/go-jose/v3@v3.0.4/jwt/builder.go:225 +0x58
github.com/go-jose/go-jose/v3/jwt.(*signedBuilder).CompactSerialize(0x0?)
	/Users/milas/dev/go/pkg/mod/github.com/go-jose/go-jose/v3@v3.0.4/jwt/builder.go:198 +0x1c
github.com/okta/okta-sdk-golang/v5/okta.createClientAssertion({0x103424595, 0x1e}, {0x0, 0x0}, {0x0, 0x0})
	/Users/milas/dev/go/pkg/mod/github.com/okta/okta-sdk-golang/v5@v5.0.6/okta/client.go:691 +0x18c
github.com/okta/okta-sdk-golang/v5/okta.getAccessTokenForPrivateKey(0x14000142390, {0x103424595, 0x1e}, {0x1400016e2c0, 0x2b4}, {0x140000c0580, 0x32}, {0x1400009ec80, 0x1, 0x1}, ...)
	/Users/milas/dev/go/pkg/mod/github.com/okta/okta-sdk-golang/v5@v5.0.6/okta/client.go:731 +0x930
github.com/okta/okta-sdk-golang/v5/okta.(*JWKAuth).Authorize(0x140000e4180, {0x103415198, 0x3}, {0x140000c05c0, 0x2a})
	/Users/milas/dev/go/pkg/mod/github.com/okta/okta-sdk-golang/v5@v5.0.6/okta/client.go:582 +0x538
github.com/okta/okta-sdk-golang/v5/okta.(*APIClient).prepareRequest(0x1400011c688, {0x10370f270, 0x103a92800}, {0x140000d0b10, 0x26}, {0x103415198, 0x3}, {0x0?, 0x0?}, 0x14000039c18, ...)
	/Users/milas/dev/go/pkg/mod/github.com/okta/okta-sdk-golang/v5@v5.0.6/okta/client.go:1256 +0x14d0
```

Fixes N/A

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version: 1.25.0
Os Version: n/a
OpenAPI Spec Version: n/a

## Signoff
- [ ] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I ran `make fmt` on my code
  - I did this but it changed a TON of unrelated stuff; my commit is properly formatted though
- [x] I did not edit any automatically generated files
