### PR TITLE
release: prepare v6.0.1 release

### DIFF
--- a/.generator/config.yaml
+++ b/.generator/config.yaml
@@ -10,7 +10,7 @@ additionalProperties:
   enumClassPrefix: true
   generateInterfaces: true
   packageName: okta
-  packageVersion: 6.0.0
+  packageVersion: 6.0.1
   useOneOfDiscriminatorLookup: true
   disallowAdditionalPropertiesIfNotPresent: false
 files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Running changelog of releases since `2.0.0-rc.4`
 
+## v6.0.1
+- Fix role assignment APIs `oneOf` schema issues in spec [#553](https://github.com/okta/okta-sdk-golang/pull/553). Thanks [@pranav-okta](https://github.com/okta/pranav-okta)
+
 ## v6.0.0
 - Update to latest Okta Management API specification
 - Breaking changes from v5.x - see [migration guide](MIGRATING.md)


### PR DESCRIPTION
## v6.0.1
- Fix role assignment APIs `oneOf` schema issues in spec [#553](https://github.com/okta/okta-sdk-golang/pull/553). Thanks [@pranav-okta](https://github.com/okta/pranav-okta)
