### PR TITLE
fix: Change `Policy.Embedded` to `map[string]interface{}`

### DIFF
--- a/okta/model_policy.go
+++ b/okta/model_policy.go
@@ -51,9 +51,9 @@ type Policy struct {
 	// Specifies whether Okta created the policy
 	System *bool `json:"system,omitempty"`
 	// All Okta orgs contain only one IdP discovery policy with an immutable default rule routing to your org's sign-in page, one entity risk policy, and one session protection policy. Creating or replacing a policy with the `IDP_DISCOVERY` type, the `ENTITY_RISK` type, or the `POST_AUTH_SESSION` type isn't supported. The following policy types are available with Identity Engine: `ACCESS_POLICY`, `PROFILE_ENROLLMENT`, `POST_AUTH_SESSION`, <x-lifecycle class=\"ea\"></x-lifecycle> `DEVICE_SIGNAL_COLLECTION`, `ENTITY_RISK`.
-	Type                 string                            `json:"type"`
-	Embedded             map[string]map[string]interface{} `json:"_embedded,omitempty"`
-	Links                *PolicyLinks                      `json:"_links,omitempty"`
+	Type                 string                 `json:"type"`
+	Embedded             map[string]interface{} `json:"_embedded,omitempty"`
+	Links                *PolicyLinks           `json:"_links,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -355,9 +355,9 @@ func (o *Policy) SetType(v string) {
 }
 
 // GetEmbedded returns the Embedded field value if set, zero value otherwise.
-func (o *Policy) GetEmbedded() map[string]map[string]interface{} {
+func (o *Policy) GetEmbedded() map[string]interface{} {
 	if o == nil || IsNil(o.Embedded) {
-		var ret map[string]map[string]interface{}
+		var ret map[string]interface{}
 		return ret
 	}
 	return o.Embedded
@@ -365,9 +365,9 @@ func (o *Policy) GetEmbedded() map[string]map[string]interface{} {
 
 // GetEmbeddedOk returns a tuple with the Embedded field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *Policy) GetEmbeddedOk() (map[string]map[string]interface{}, bool) {
+func (o *Policy) GetEmbeddedOk() (map[string]interface{}, bool) {
 	if o == nil || IsNil(o.Embedded) {
-		return map[string]map[string]interface{}{}, false
+		return map[string]interface{}{}, false
 	}
 	return o.Embedded, true
 }
@@ -381,8 +381,8 @@ func (o *Policy) HasEmbedded() bool {
 	return false
 }
 
-// SetEmbedded gets a reference to the given map[string]map[string]interface{} and assigns it to the Embedded field.
-func (o *Policy) SetEmbedded(v map[string]map[string]interface{}) {
+// SetEmbedded gets a reference to the given map[string]interface{} and assigns it to the Embedded field.
+func (o *Policy) SetEmbedded(v map[string]interface{}) {
 	o.Embedded = v
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:

- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

I already signed the CLA a while back for https://github.com/okta/okta-sdk-golang/pulls?q=is%3Apr+author%3Aerezrokah+is%3Aclosed. I can send it again if you don't have it

## Summary
<!-- Be concise with your summery, but explain what changed -->

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
This PR aims to fix the issue reported in this comment https://github.com/okta/okta-sdk-golang/issues/557#issuecomment-3607412731

Not sure how to do this in the code gen, so opening for feedback

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
<!-- Please fill out all information -->
- [ ] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

Go Version: `go version go1.25.4 darwin/arm64`
Os Version: MacOS 26.1
OpenAPI Spec Version:


## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files
