### PR TITLE
fix: skip list policy apps test deprecated endpoint

### DIFF
--- a/okta/test/api_policy_test.go
+++ b/okta/test/api_policy_test.go
@@ -455,6 +455,8 @@ func Test_okta_PolicyAPIService(t *testing.T) {
 	})
 
 	t.Run("Test PolicyAPIService ListPolicyApps", func(t *testing.T) {
+		// This is a deprecated endpoint
+		t.Skip()
 		var testFactoryInstance okta.TestFactory
 		policyRequest := testFactoryInstance.NewValidTestCreatePolicyRequest()
 


### PR DESCRIPTION
This PR skips the `ListPolicyApps` test since this is a deprecated endpoint.