### PR TITLE
fix: dropped client errors

### DIFF
--- a/okta/client.go
+++ b/okta/client.go
@@ -805,6 +805,9 @@ func getAccessTokenForPrivateKey(httpClient *http.Client, orgURL, clientAssertio
 	}
 
 	respBody, err := io.ReadAll(tokenResponse.Body)
+	if err != nil {
+		return nil, "", nil, err
+	}
 	origResp := io.NopCloser(bytes.NewBuffer(respBody))
 	tokenResponse.Body = origResp
 	var accessToken *RequestAccessToken
@@ -883,7 +886,7 @@ func getAccessTokenForDpopPrivateKey(tokenRequest *http.Request, httpClient *htt
 	tokenResponse.Body = origResp
 	var accessToken *RequestAccessToken
 	_, err = buildResponse(tokenResponse, nil, &accessToken)
-	return accessToken, nonce, privateKey, nil
+	return accessToken, nonce, privateKey, err
 }
 
 // NewAPIClient creates a new API client. Requires a userAgent string describing your application.


### PR DESCRIPTION
This fixes two dropped `err` variables in the `client.go` file in the `okta` package.

I can deal with a CLA if this is more than an "obvious fix."