### PR TITLE
fix: make grant_types optional in OpenIdConnectApplicationSettingsClient

### DIFF
--- a/.generator/okta-management-APIs-oasv3-noEnums-inheritance.yaml
+++ b/.generator/okta-management-APIs-oasv3-noEnums-inheritance.yaml
@@ -44553,8 +44553,6 @@ components:
               For example, if `https://redirect-*-domain.example.com/oidc/redirect` is configured as a redirect URI, then `https://redirect-1-domain.example.com/oidc/redirect` and `https://redirect-sub-domain.example.com/oidc/redirect` match, but `https://redirect-1.sub-domain.example.com/oidc/redirect` doesn't match.
               Only the `https` URI scheme can use wildcard redirect URIs.
               > **Note:** The use of wildcard subdomains is discouraged as an insecure practice, since it may allow malicious actors to have tokens or authorization codes sent to unexpected or attacker-controlled pages. Exercise caution if you decide to include a wildcard redirect URI in your configuration.
-      required:
-        - grant_types
     OpenIdConnectApplicationSettingsClientKeys:
       description: A [JSON Web Key Set](https://tools.ietf.org/html/rfc7517#section-5) for validating JWTs presented to Okta or for encrypting ID tokens minted by Okta for the client
       type: object

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ func main() {
   }
   client := okta.NewAPIClient(config)
 
-  settingClient := okta.NewOpenIdConnectApplicationSettingsClient([]string{"grantTypes"})
+  settingClient := okta.NewOpenIdConnectApplicationSettingsClient()
   settingClient.SetClientUri("https://example.com/client")
   settingClient.SetLogoUri("https://example.com/assets/images/logo-new.png")
   settingClient.SetResponseTypes([]string{"token", "id_token", "code"})

--- a/okta/api/openapi.yaml
+++ b/okta/api/openapi.yaml
@@ -70077,8 +70077,6 @@ components:
               For example, if `https://redirect-*-domain.example.com/oidc/redirect` is configured as a redirect URI, then `https://redirect-1-domain.example.com/oidc/redirect` and `https://redirect-sub-domain.example.com/oidc/redirect` match, but `https://redirect-1.sub-domain.example.com/oidc/redirect` doesn't match.
               Only the `https` URI scheme can use wildcard redirect URIs.
               > **Note:** The use of wildcard subdomains is discouraged as an insecure practice, since it may allow malicious actors to have tokens or authorization codes sent to unexpected or attacker-controlled pages. Exercise caution if you decide to include a wildcard redirect URI in your configuration.
-      required:
-      - grant_types
       type: object
     OpenIdConnectApplicationSettingsClientKeys:
       description: "A [JSON Web Key Set](https://tools.ietf.org/html/rfc7517#section-5)\

--- a/okta/docs/OpenIdConnectApplicationSettingsClient.md
+++ b/okta/docs/OpenIdConnectApplicationSettingsClient.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **DpopBoundAccessTokens** | Pointer to **bool** | Indicates that the client application uses Demonstrating Proof-of-Possession (DPoP) for token requests. If &#x60;true&#x60;, the authorization server rejects token requests from this client that don&#39;t contain the DPoP header. &gt; **Note:** If &#x60;dpop_bound_access_tokens&#x60; is true, then &#x60;client_credentials&#x60; and &#x60;implicit&#x60; aren&#39;t allowed in &#x60;grant_types&#x60;.  | [optional] [default to false]
 **FrontchannelLogoutSessionRequired** | Pointer to **bool** | &lt;x-lifecycle-container&gt;&lt;x-lifecycle class&#x3D;\&quot;ea\&quot;&gt;&lt;/x-lifecycle&gt; &lt;x-lifecycle class&#x3D;\&quot;oie\&quot;&gt;&lt;/x-lifecycle&gt;&lt;/x-lifecycle-container&gt;Determines whether Okta sends &#x60;sid&#x60; and &#x60;iss&#x60; in the logout request | [optional] 
 **FrontchannelLogoutUri** | Pointer to **string** | &lt;x-lifecycle-container&gt;&lt;x-lifecycle class&#x3D;\&quot;ea\&quot;&gt;&lt;/x-lifecycle&gt; &lt;x-lifecycle class&#x3D;\&quot;oie\&quot;&gt;&lt;/x-lifecycle&gt;&lt;/x-lifecycle-container&gt;URL where Okta sends the logout request | [optional] 
-**GrantTypes** | **[]string** |  | 
+**GrantTypes** | **[]string** |  | [optional] 
 **IdTokenEncryptedResponseAlg** | Pointer to **string** | JWE alg algorithm for encrypting the ID token issued to this client. If this is requested, the response is signed, and then encrypted with the result being a nested JWT. The default, if omitted, is that no encryption is performed. See the [Application Public Keys API](/openapi/okta-management/management/applicationssopublickeys/) for more information on encryption keys. See [Key management](https://developer.okta.com/docs/guides/key-management/main/) for more information on how encryption keys are used. | [optional] 
 **IdpInitiatedLogin** | Pointer to [**OpenIdConnectApplicationIdpInitiatedLogin**](OpenIdConnectApplicationIdpInitiatedLogin.md) |  | [optional] 
 **InitiateLoginUri** | Pointer to **string** | URL string that a third party can use to initiate the sign-in flow by the client | [optional] 
@@ -38,7 +38,7 @@ Name | Type | Description | Notes
 
 ### NewOpenIdConnectApplicationSettingsClient
 
-`func NewOpenIdConnectApplicationSettingsClient(grantTypes []string, ) *OpenIdConnectApplicationSettingsClient`
+`func NewOpenIdConnectApplicationSettingsClient() *OpenIdConnectApplicationSettingsClient`
 
 NewOpenIdConnectApplicationSettingsClient instantiates a new OpenIdConnectApplicationSettingsClient object
 This constructor will assign default values to properties that have it defined,

--- a/okta/model_open_id_connect_application_settings_client.go
+++ b/okta/model_open_id_connect_application_settings_client.go
@@ -25,7 +25,6 @@ package okta
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 // checks if the OpenIdConnectApplicationSettingsClient type satisfies the MappedNullable interface at compile time
@@ -51,7 +50,7 @@ type OpenIdConnectApplicationSettingsClient struct {
 	FrontchannelLogoutSessionRequired *bool `json:"frontchannel_logout_session_required,omitempty"`
 	// <x-lifecycle-container><x-lifecycle class=\"ea\"></x-lifecycle> <x-lifecycle class=\"oie\"></x-lifecycle></x-lifecycle-container>URL where Okta sends the logout request
 	FrontchannelLogoutUri *string  `json:"frontchannel_logout_uri,omitempty"`
-	GrantTypes            []string `json:"grant_types"`
+	GrantTypes            []string `json:"grant_types,omitempty"`
 	// JWE alg algorithm for encrypting the ID token issued to this client. If this is requested, the response is signed, and then encrypted with the result being a nested JWT. The default, if omitted, is that no encryption is performed. See the [Application Public Keys API](/openapi/okta-management/management/applicationssopublickeys/) for more information on encryption keys. See [Key management](https://developer.okta.com/docs/guides/key-management/main/) for more information on how encryption keys are used.
 	IdTokenEncryptedResponseAlg *string                                    `json:"id_token_encrypted_response_alg,omitempty"`
 	IdpInitiatedLogin           *OpenIdConnectApplicationIdpInitiatedLogin `json:"idp_initiated_login,omitempty"`
@@ -95,13 +94,12 @@ type _OpenIdConnectApplicationSettingsClient OpenIdConnectApplicationSettingsCli
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewOpenIdConnectApplicationSettingsClient(grantTypes []string) *OpenIdConnectApplicationSettingsClient {
+func NewOpenIdConnectApplicationSettingsClient() *OpenIdConnectApplicationSettingsClient {
 	this := OpenIdConnectApplicationSettingsClient{}
 	var consentMethod string = "TRUSTED"
 	this.ConsentMethod = &consentMethod
 	var dpopBoundAccessTokens bool = false
 	this.DpopBoundAccessTokens = &dpopBoundAccessTokens
-	this.GrantTypes = grantTypes
 	return &this
 }
 
@@ -405,20 +403,19 @@ func (o *OpenIdConnectApplicationSettingsClient) SetFrontchannelLogoutUri(v stri
 	o.FrontchannelLogoutUri = &v
 }
 
-// GetGrantTypes returns the GrantTypes field value
+// GetGrantTypes returns the GrantTypes field value if set, zero value otherwise.
 func (o *OpenIdConnectApplicationSettingsClient) GetGrantTypes() []string {
-	if o == nil {
+	if o == nil || o.GrantTypes == nil {
 		var ret []string
 		return ret
 	}
-
 	return o.GrantTypes
 }
 
-// GetGrantTypesOk returns a tuple with the GrantTypes field value
+// GetGrantTypesOk returns a tuple with the GrantTypes field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *OpenIdConnectApplicationSettingsClient) GetGrantTypesOk() ([]string, bool) {
-	if o == nil {
+	if o == nil || o.GrantTypes == nil {
 		return nil, false
 	}
 	return o.GrantTypes, true
@@ -1074,7 +1071,9 @@ func (o OpenIdConnectApplicationSettingsClient) ToMap() (map[string]interface{},
 	if !IsNil(o.FrontchannelLogoutUri) {
 		toSerialize["frontchannel_logout_uri"] = o.FrontchannelLogoutUri
 	}
-	toSerialize["grant_types"] = o.GrantTypes
+	if o.GrantTypes != nil {
+		toSerialize["grant_types"] = o.GrantTypes
+	}
 	if !IsNil(o.IdTokenEncryptedResponseAlg) {
 		toSerialize["id_token_encrypted_response_alg"] = o.IdTokenEncryptedResponseAlg
 	}
@@ -1141,27 +1140,6 @@ func (o OpenIdConnectApplicationSettingsClient) ToMap() (map[string]interface{},
 }
 
 func (o *OpenIdConnectApplicationSettingsClient) UnmarshalJSON(data []byte) (err error) {
-	// This validates that all required properties are included in the JSON object
-	// by unmarshalling the object into a generic map with string keys and checking
-	// that every required field exists as a key in the generic map.
-	requiredProperties := []string{
-		"grant_types",
-	}
-
-	allProperties := make(map[string]interface{})
-
-	err = json.Unmarshal(data, &allProperties)
-
-	if err != nil {
-		return err
-	}
-
-	for _, requiredProperty := range requiredProperties {
-		if _, exists := allProperties[requiredProperty]; !exists {
-			return fmt.Errorf("no value given for required property %v", requiredProperty)
-		}
-	}
-
 	varOpenIdConnectApplicationSettingsClient := _OpenIdConnectApplicationSettingsClient{}
 
 	err = json.Unmarshal(data, &varOpenIdConnectApplicationSettingsClient)


### PR DESCRIPTION
obvious fix

## Summary

The Okta API does not always return `grant_types` in OIDC app responses,
but the OpenAPI spec marks it as required. This causes `UnmarshalJSON` to
fail with:

    no value given for required property grant_types

Applies the same fix pattern introduced in #559 to a field that PR did
not cover. Changes:
- Remove `grant_types` from the `required` list in both spec YAML files
- Regenerated Go model via `make generate` (working tree clean after)
- No other files affected

Fixes #N/A

## Type of PR
- [x] Bug Fix (non-breaking fixes to existing functionality)

## Test Information
- [ ] My PR required test updates

Go Version: go1.25.6 darwin/arm64
OS Version: macOS 15.7.2 (darwin/arm64)
OpenAPI Spec Version: openapi-generator-cli 7.15.0

## Signoff
- [ ] I have submitted a CLA for this PR
      (Claiming the obvious fix exception — this change removes an incorrectly
      required field with no new functionality added, following the same pattern
      already established in #559. If this does not qualify, please let me know
      and I will sign the CLA promptly.)
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files