### PR TITLE
fix: surface /oauth2/v1/token errors instead of "Empty access token"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 Running changelog of releases since `2.0.0-rc.4`
 
+## Unreleased
+- Surface real errors from the `/oauth2/v1/token` endpoint when using `PrivateKey`/`JWT` auth. Previously a 4xx/5xx token response was silently swallowed and callers saw a misleading "Empty access token" error instead of Okta's actual `error` / `error_description` (e.g. `invalid_client`, `invalid_scope`). DPoP routing on `invalid_dpop_proof` / `use_dpop_nonce` is preserved. See [#452](https://github.com/okta/okta-sdk-golang/pull/452) for prior context.
+
 ## v6.1.6
 - Fix UserIdentifierPolicyRuleCondition by making patterns and type as optional parameters. Thanks [@pranav-okta](https://github.com/pranav-okta)
 

--- a/okta/client.go
+++ b/okta/client.go
@@ -767,6 +767,24 @@ func createKeySigner(privateKey, privateKeyID string) (jose.Signer, error) {
 	return nil, fmt.Errorf("private key %q is not pkcs#1 or pkcs#8 format", privPem.Type)
 }
 
+// tokenEndpointError formats an error from a failed Okta /oauth2/v1/token
+// response. When the body is JSON it prefers the standard OAuth2 `error` and
+// `error_description` fields; otherwise it falls back to the raw body. The
+// HTTP status code is always included so callers can distinguish 4xx from 5xx.
+func tokenEndpointError(statusCode int, body []byte) error {
+	var parsed struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if jsonErr := json.Unmarshal(body, &parsed); jsonErr == nil && parsed.Error != "" {
+		if parsed.ErrorDescription != "" {
+			return fmt.Errorf("okta token endpoint returned HTTP %d: %s: %s", statusCode, parsed.Error, parsed.ErrorDescription)
+		}
+		return fmt.Errorf("okta token endpoint returned HTTP %d: %s", statusCode, parsed.Error)
+	}
+	return fmt.Errorf("okta token endpoint returned HTTP %d: %s", statusCode, strings.TrimSpace(string(body)))
+}
+
 func createClientAssertion(orgURL, clientID string, privateKeySinger jose.Signer) (clientAssertion string, err error) {
 	claims := ClientAssertionClaims{
 		Subject:  clientID,
@@ -826,7 +844,7 @@ func getAccessTokenForPrivateKey(httpClient *http.Client, orgURL, clientAssertio
 		if strings.Contains(string(respBody), "invalid_dpop_proof") {
 			return getAccessTokenForDpopPrivateKey(tokenRequest, httpClient, orgURL, "", maxRetries, maxBackoff, newClientAssertion, strings.Join(scopes, " "), clientID, signer)
 		} else {
-			return nil, "", nil, err
+			return nil, "", nil, tokenEndpointError(tokenResponse.StatusCode, respBody)
 		}
 	}
 
@@ -884,7 +902,7 @@ func getAccessTokenForDpopPrivateKey(tokenRequest *http.Request, httpClient *htt
 			newNonce := tokenResponse.Header.Get("Dpop-Nonce")
 			return getAccessTokenForDpopPrivateKey(tokenRequest, httpClient, orgURL, newNonce, maxRetries, maxBackoff, clientAssertion, scopes, clientID, signer)
 		} else {
-			return nil, "", nil, err
+			return nil, "", nil, tokenEndpointError(tokenResponse.StatusCode, respBody)
 		}
 	}
 	origResp := io.NopCloser(bytes.NewBuffer(respBody))

--- a/okta/client_oauth_test.go
+++ b/okta/client_oauth_test.go
@@ -1,0 +1,213 @@
+package okta
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestSigner builds an RSA key and matching jose.Signer for exercising
+// getAccessTokenForPrivateKey end-to-end without network. Matches the
+// 2048-bit size used by the existing PrivateKey-mode tests.
+func newTestSigner(t *testing.T) jose.Signer {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: priv},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+	return signer
+}
+
+// TestGetAccessTokenForPrivateKey_TokenEndpointErrors regression-tests the bug
+// where a 4xx/5xx /oauth2/v1/token response was silently swallowed
+// (return nil, "", nil, err with err==nil), causing callers to surface the
+// misleading "Empty access token" message instead of Okta's actual error.
+func TestGetAccessTokenForPrivateKey_TokenEndpointErrors(t *testing.T) {
+	signer := newTestSigner(t)
+
+	cases := []struct {
+		name        string
+		status      int
+		body        string
+		contentType string
+		wantSubs    []string
+	}{
+		{
+			name:        "401 invalid_client",
+			status:      http.StatusUnauthorized,
+			contentType: "application/json",
+			body:        `{"error":"invalid_client","error_description":"Client authentication failed"}`,
+			wantSubs:    []string{"401", "invalid_client", "Client authentication failed"},
+		},
+		{
+			name:        "403 invalid_scope",
+			status:      http.StatusForbidden,
+			contentType: "application/json",
+			body:        `{"error":"invalid_scope","error_description":"One or more scopes are not configured for the authorization server"}`,
+			wantSubs:    []string{"403", "invalid_scope", "scopes are not configured"},
+		},
+		{
+			name:        "500 non-JSON body falls back to raw body",
+			status:      http.StatusInternalServerError,
+			contentType: "text/plain",
+			body:        "internal server error",
+			wantSubs:    []string{"500", "internal server error"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "/oauth2/v1/token", r.URL.Path)
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			httpClient := &http.Client{Timeout: 5 * time.Second}
+			token, _, _, err := getAccessTokenForPrivateKey(
+				httpClient, server.URL, "assertion-stub", "test-ua",
+				[]string{"okta.users.read"}, 0, 1,
+				"test-client-id", signer,
+			)
+
+			require.Error(t, err, "expected non-nil error for status %d", tc.status)
+			require.Nil(t, token, "token must be nil when token endpoint returns an error")
+			for _, sub := range tc.wantSubs {
+				require.Contains(t, err.Error(), sub,
+					"error %q must contain %q", err.Error(), sub)
+			}
+		})
+	}
+}
+
+// TestGetAccessTokenForPrivateKey_Success is a regression check: a 200 response
+// with a well-formed token payload must still return a populated token and a
+// nil error (the fix must not break the happy path).
+func TestGetAccessTokenForPrivateKey_Success(t *testing.T) {
+	signer := newTestSigner(t)
+
+	const tokenBody = `{"token_type":"Bearer","expires_in":3600,"access_token":"test-access-token","scope":"okta.users.read"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/oauth2/v1/token", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(tokenBody))
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	got, nonce, dpopKey, err := getAccessTokenForPrivateKey(
+		httpClient, server.URL, "assertion-stub", "test-ua",
+		[]string{"okta.users.read"}, 0, 1,
+		"test-client-id", signer,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "test-access-token", got.AccessToken)
+	require.Equal(t, "Bearer", got.TokenType)
+	require.Equal(t, 3600, got.ExpiresIn)
+	require.Equal(t, "", nonce)
+	require.Nil(t, dpopKey)
+}
+
+// TestGetAccessTokenForPrivateKey_DpopPassthrough verifies that an
+// `invalid_dpop_proof` response still routes into the DPoP retry path. This
+// guards against the fix accidentally turning the DPoP delegation into a
+// surfaced error.
+func TestGetAccessTokenForPrivateKey_DpopPassthrough(t *testing.T) {
+	signer := newTestSigner(t)
+
+	const dpopTokenBody = `{"token_type":"DPoP","expires_in":3600,"access_token":"dpop-access-token","scope":"okta.users.read"}`
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/oauth2/v1/token", r.URL.Path)
+		n := calls.Add(1)
+		switch n {
+		case 1:
+			// Initial call without DPoP header — trigger the DPoP path.
+			require.Empty(t, r.Header.Get("DPoP"))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_dpop_proof","error_description":"DPoP proof required"}`))
+		case 2:
+			// DPoP-bearing retry — must succeed.
+			require.NotEmpty(t, r.Header.Get("DPoP"), "DPoP retry must include DPoP header")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(dpopTokenBody))
+		default:
+			t.Fatalf("unexpected request #%d", n)
+		}
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	got, _, dpopKey, err := getAccessTokenForPrivateKey(
+		httpClient, server.URL, "assertion-stub", "test-ua",
+		[]string{"okta.users.read"}, 0, 1,
+		"test-client-id", signer,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "dpop-access-token", got.AccessToken)
+	require.Equal(t, "DPoP", got.TokenType)
+	require.NotNil(t, dpopKey, "DPoP path must return a private key for proof generation")
+	require.Equal(t, int32(2), calls.Load(), "expected exactly one DPoP retry")
+}
+
+// TestGetAccessTokenForDpopPrivateKey_NonNonceErrorReturned regression-tests
+// the second buggy site: when the DPoP-bearing request itself fails with a
+// non-`use_dpop_nonce` error, the helper must surface a real error rather
+// than returning (nil, "", nil, nil).
+func TestGetAccessTokenForDpopPrivateKey_NonNonceErrorReturned(t *testing.T) {
+	signer := newTestSigner(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/oauth2/v1/token", r.URL.Path)
+		n := calls.Add(1)
+		switch n {
+		case 1:
+			// First (non-DPoP) call returns invalid_dpop_proof, triggering DPoP.
+			require.Empty(t, r.Header.Get("DPoP"))
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_dpop_proof"}`))
+		case 2:
+			// DPoP retry fails with a real error (not use_dpop_nonce).
+			require.NotEmpty(t, r.Header.Get("DPoP"))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"Client authentication failed"}`))
+		default:
+			t.Fatalf("unexpected request #%d", n)
+		}
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	token, _, _, err := getAccessTokenForPrivateKey(
+		httpClient, server.URL, "assertion-stub", "test-ua",
+		[]string{"okta.users.read"}, 0, 1,
+		"test-client-id", signer,
+	)
+
+	require.Error(t, err, "DPoP retry that fails with non-nonce error must surface an error")
+	require.Nil(t, token)
+	require.Contains(t, err.Error(), "401")
+	require.Contains(t, err.Error(), "invalid_client")
+}


### PR DESCRIPTION
## Summary
`getAccessTokenForPrivateKey` (and its DPoP sibling) silently swallow Okta's
token-endpoint error response on HTTP 4xx/5xx, returning `(nil, "", nil, nil)`.
Callers therefore surface a misleading "Empty access token" message and the real
reason (`invalid_client`, `invalid_scope`, etc.) is lost.

Fixes #

## Why this PR exists (not a duplicate of #452)
#452 was closed in May 2024 with the comment "fixed in v4." That is incorrect —
the same buggy pattern is present on `master` today (see `okta/client.go:829`
and `okta/client.go:887` before this PR). I verified by reading the source on
`master`, `v6.1.6`, `v5.0.6`, and `v4.1.2`: all four return `nil, "", nil, err`
where `err` was just nilled by a successful `io.ReadAll` (and, in v5/v6, by a
subsequent `createClientAssertion` call). The fix has never landed.

## Repro
Configure any client with PrivateKey auth using a `client_id` that Okta will
reject (or scopes Okta will reject, or any other 4xx case other than
`invalid_dpop_proof`). The SDK returns no token and no error; downstream code
falls through to `if accessToken == nil { return errors.New("Empty access token") }`
at `okta/client.go:463` / `:554` / `:675`, hiding Okta's actual response body.

## Fix
On `StatusCode >= 300`, return an error built from the HTTP status and the
response body via a new private helper `tokenEndpointError`. The helper parses
standard OAuth2 `error` / `error_description` fields when the body is JSON and
falls back to the raw body otherwise; the HTTP status is always included.

The change is intentionally minimal:
- Function signatures, return types, and all three call sites are unchanged.
- DPoP routing on `invalid_dpop_proof` (first helper) and `use_dpop_nonce`
  (second helper) is preserved verbatim.
- The pre-existing `err = ...` shadowing pattern around `io.ReadAll` and
  `createClientAssertion` is *not* touched — that's a separate cleanup and
  would expand the diff.

## Tests
New table-driven tests in `okta/client_oauth_test.go` using `httptest.Server`
to mock `/oauth2/v1/token`, with a real in-test RSA key + `jose.Signer`:

- `TestGetAccessTokenForPrivateKey_TokenEndpointErrors` — 401 `invalid_client`,
  403 `invalid_scope`, 500 with non-JSON body (raw-body fallback). Asserts the
  returned error is non-nil, contains the status code, and contains the Okta
  `error` / `error_description` substrings.
- `TestGetAccessTokenForPrivateKey_Success` — 200 with a valid token payload
  still returns a populated `*RequestAccessToken` and `err == nil` (happy-path
  regression).
- `TestGetAccessTokenForPrivateKey_DpopPassthrough` — 400 `invalid_dpop_proof`
  still triggers the DPoP retry; the retry (verified by `DPoP` header) returns
  success.
- `TestGetAccessTokenForDpopPrivateKey_NonNonceErrorReturned` — exercises the
  second buggy site: when the DPoP-bearing retry itself fails with a
  non-`use_dpop_nonce` error, a real error is now surfaced.

The existing `TestAPIClient_doWithRetries/token_retries_for_PrivateKey_mode`
end-to-end test (which round-trips `invalid_dpop_proof` → `use_dpop_nonce` →
success through a real `*APIClient`) still passes.

## Type of PR
- [x] Bug Fix (non-breaking fixes to existing functionality)

## Test Information
- [x] My PR required test updates

Go Version: go1.23+
Os Version: darwin/arm64 (verified locally; CI matrix applies)
OpenAPI Spec Version: 2025.08.0 (unchanged)

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does (CHANGELOG)
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)