### PR TITLE
fix: attempt DPoP up front in private-key token flow

### DIFF
--- a/.generator/templates/client.mustache
+++ b/.generator/templates/client.mustache
@@ -295,6 +295,10 @@ func (a *JWTAuth) Authorize(method, URL string) error {
 			}
 		}
 	} else {
+		// JWTAuth only has a caller-supplied assertion and no signer, so it cannot
+		// mint a fresh one. A use_dpop_nonce retry would replay this assertion; for
+		// a DPoP-required org, JWT mode therefore requires the caller to supply a
+		// reusable assertion. (Non-DPoP orgs are unaffected — single request.)
 		accessToken, nonce, privateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, a.clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, "", nil)
 		if err != nil {
 			return err
@@ -416,7 +420,9 @@ func (a *JWKAuth) Authorize(method, URL string) error {
 			return err
 		}
 
-		accessToken, nonce, dpopPrivateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, "", nil)
+		// Pass the signer so a use_dpop_nonce retry can mint a fresh (single-use)
+		// client assertion rather than replaying this one.
+		accessToken, nonce, dpopPrivateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, a.clientId, a.privateKeySigner)
 		if err != nil {
 			return err
 		}
@@ -530,118 +536,123 @@ func createClientAssertion(orgURL, clientID string, privateKeySinger jose.Signer
 	return jwtBuilder.Serialize()
 }
 
+// getAccessTokenForPrivateKey requests an access token using the private-key /
+// JWT client-credentials flow, attempting DPoP up front (DPoP-first).
+//
+// Previously this sent the first token request without a DPoP proof and only
+// retried with one after Okta rejected it with invalid_dpop_proof. For an app
+// with "Require DPoP" enabled, that proofless request is recorded as a failed
+// token grant in the org System Log on every token acquisition, and costs an
+// extra round trip. Per RFC 9449, a DPoP-capable client should attach a proof
+// proactively, so the proofless request never happens.
+//
+// The first successful response is then adapted to: if Okta issued a DPoP-bound
+// token, DPoP material is returned so the caller attaches per-request proofs; if
+// the app does not require DPoP, Okta ignores the proof and returns a Bearer
+// token, in which case the DPoP material is dropped and Bearer is used.
 func getAccessTokenForPrivateKey(httpClient *http.Client, orgURL, clientAssertion, userAgent string, scopes []string, maxRetries int32, maxBackoff int64, clientID string, signer jose.Signer) (*RequestAccessToken, string, *rsa.PrivateKey, error) {
-	query := url.Values{}
 	tokenRequestURL := orgURL + "/oauth2/v1/token"
 
-	query.Add("grant_type", "client_credentials")
-	query.Add("scope", strings.Join(scopes, " "))
-	query.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
-	query.Add("client_assertion", clientAssertion)
-
-	tokenRequest, err := http.NewRequest("POST", tokenRequestURL, strings.NewReader(query.Encode()))
-	if err != nil {
-		return nil, "", nil, err
-	}
-	tokenRequest.Header.Add("Accept", "application/json")
-	tokenRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	tokenRequest.Header.Add("User-Agent", userAgent)
-	bOff := &oktaBackoff{
-		ctx:             context.Background(),
-		maxRetries:      maxRetries,
-		backoffDuration: time.Duration(maxBackoff),
-	}
-	var tokenResponse *http.Response
-	operation := func() (*http.Response, error) {
-		resp, err := httpClient.Do(tokenRequest)
-		bOff.retryCount++
-		return resp, err
-	}
-	tokenResponse, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(bOff))
+	// One DPoP key is generated and reused across the use_dpop_nonce retry.
+	dpopKey, err := generatePrivateKey(2048)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
-	respBody, err := io.ReadAll(tokenResponse.Body)
-	origResp := io.NopCloser(bytes.NewBuffer(respBody))
-	tokenResponse.Body = origResp
-	var accessToken *RequestAccessToken
-
-	newClientAssertion, err := createClientAssertion(orgURL, clientID, signer)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	if tokenResponse.StatusCode >= 300 {
-		if strings.Contains(string(respBody), "invalid_dpop_proof") {
-			return getAccessTokenForDpopPrivateKey(tokenRequest, httpClient, orgURL, "", maxRetries, maxBackoff, newClientAssertion, strings.Join(scopes, " "), clientID, signer)
-		} else {
+	// nonce is empty on the first attempt; if the app requires DPoP, Okta
+	// responds with use_dpop_nonce and a Dpop-Nonce header, and we retry once.
+	// nonceRetried bounds that to a single retry even if the server keeps
+	// asking, and we only retry when it actually supplied a nonce.
+	nonce := ""
+	nonceRetried := false
+	for {
+		dpopJWT, err := generateDpopJWT(dpopKey, http.MethodPost, tokenRequestURL, nonce, "")
+		if err != nil {
 			return nil, "", nil, err
 		}
-	}
 
-	_, err = buildResponse(tokenResponse, nil, &accessToken)
-	if err != nil {
-		return nil, "", nil, err
-	}
-	return accessToken, "", nil, nil
-}
+		// Client assertions are single-use, so mint a fresh one per attempt when
+		// a signer is available; otherwise reuse the caller-supplied assertion.
+		assertion := clientAssertion
+		if signer != nil {
+			assertion, err = createClientAssertion(orgURL, clientID, signer)
+			if err != nil {
+				return nil, "", nil, err
+			}
+		}
 
-func getAccessTokenForDpopPrivateKey(tokenRequest *http.Request, httpClient *http.Client, orgURL, nonce string, maxRetries int32, maxBackoff int64, clientAssertion string, scopes string, clientID string, signer jose.Signer) (*RequestAccessToken, string, *rsa.PrivateKey, error) {
-	privateKey, err := generatePrivateKey(2048)
-	if err != nil {
-		return nil, "", nil, err
-	}
-	dpopJWT, err := generateDpopJWT(privateKey, http.MethodPost, fmt.Sprintf("%v%v", orgURL, "/oauth2/v1/token"), nonce, "")
-	if err != nil {
-		return nil, "", nil, err
-	}
-	newClientAssertion, err := createClientAssertion(orgURL, clientID, signer)
-	if err != nil {
-		return nil, "", nil, err
-	}
+		query := url.Values{}
+		query.Add("grant_type", "client_credentials")
+		query.Add("scope", strings.Join(scopes, " "))
+		query.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+		query.Add("client_assertion", assertion)
+		body := query.Encode()
 
-	query := url.Values{}
-	query.Add("grant_type", "client_credentials")
-	query.Add("scope", scopes)
-	query.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
-	query.Add("client_assertion", newClientAssertion)
-	tokenRequest.Body = io.NopCloser(strings.NewReader(query.Encode()))
-	tokenRequest.Header.Set("DPoP", dpopJWT)
+		tokenRequest, err := http.NewRequest("POST", tokenRequestURL, strings.NewReader(body))
+		if err != nil {
+			return nil, "", nil, err
+		}
+		tokenRequest.Header.Add("Accept", "application/json")
+		tokenRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		tokenRequest.Header.Add("User-Agent", userAgent)
+		tokenRequest.Header.Set("DPoP", dpopJWT)
 
-	bOff := &oktaBackoff{
-		ctx:             context.Background(),
-		maxRetries:      maxRetries,
-		backoffDuration: time.Duration(maxBackoff),
-	}
-	var tokenResponse *http.Response
-	operation := func() (*http.Response, error) {
-		resp, err := httpClient.Do(tokenRequest)
-		bOff.retryCount++
-		return resp, err
-	}
-	tokenResponse, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(bOff))
-	if err != nil {
-		return nil, "", nil, err
-	}
-	respBody, err := io.ReadAll(tokenResponse.Body)
-	if err != nil {
-		return nil, "", nil, err
-	}
+		bOff := &oktaBackoff{
+			ctx:             context.Background(),
+			maxRetries:      maxRetries,
+			backoffDuration: time.Duration(maxBackoff),
+		}
+		var tokenResponse *http.Response
+		operation := func() (*http.Response, error) {
+			// Rewind the body so a transport-error backoff retry re-sends it.
+			// (429/5xx come back as a response with a nil error, so backoff does not retry them here.)
+			tokenRequest.Body = io.NopCloser(strings.NewReader(body))
+			resp, err := httpClient.Do(tokenRequest)
+			bOff.retryCount++
+			return resp, err
+		}
+		tokenResponse, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(bOff))
+		if err != nil {
+			return nil, "", nil, err
+		}
 
-	if tokenResponse.StatusCode >= 300 {
-		if strings.Contains(string(respBody), "use_dpop_nonce") {
+		respBody, err := io.ReadAll(tokenResponse.Body)
+		closeErr := tokenResponse.Body.Close()
+		if err != nil {
+			return nil, "", nil, err
+		}
+		if closeErr != nil {
+			return nil, "", nil, closeErr
+		}
+		tokenResponse.Body = io.NopCloser(bytes.NewBuffer(respBody))
+
+		if tokenResponse.StatusCode >= 300 {
+			// Retry exactly once, only if Okta asked for a nonce and provided one.
 			newNonce := tokenResponse.Header.Get("Dpop-Nonce")
-			return getAccessTokenForDpopPrivateKey(tokenRequest, httpClient, orgURL, newNonce, maxRetries, maxBackoff, clientAssertion, scopes, clientID, signer)
-		} else {
+			if !nonceRetried && newNonce != "" && strings.Contains(string(respBody), "use_dpop_nonce") {
+				nonce = newNonce
+				nonceRetried = true
+				continue
+			}
+			return nil, "", nil, fmt.Errorf("token request failed (%d): %s", tokenResponse.StatusCode, strings.TrimSpace(string(respBody)))
+		}
+
+		var accessToken *RequestAccessToken
+		if _, err = buildResponse(tokenResponse, nil, &accessToken); err != nil {
 			return nil, "", nil, err
 		}
+		if accessToken == nil || accessToken.AccessToken == "" {
+			return nil, "", nil, fmt.Errorf("token response did not contain an access token")
+		}
+
+		// If the app does not require DPoP, Okta ignores the proof and returns a
+		// Bearer token; drop the DPoP material so no per-request proof is attached
+		// and no key is reused on refresh.
+		if accessToken.TokenType != "DPoP" {
+			return accessToken, "", nil, nil
+		}
+		return accessToken, nonce, dpopKey, nil
 	}
-	origResp := io.NopCloser(bytes.NewBuffer(respBody))
-	tokenResponse.Body = origResp
-	var accessToken *RequestAccessToken
-	_, err = buildResponse(tokenResponse, nil, &accessToken)
-	return accessToken, nonce, privateKey, nil
 }
 
 // NewAPIClient creates a new API client. Requires a userAgent string describing your application.

--- a/okta/client.go
+++ b/okta/client.go
@@ -545,6 +545,10 @@ func (a *JWTAuth) Authorize(method, URL string) error {
 			}
 		}
 	} else {
+		// JWTAuth only has a caller-supplied assertion and no signer, so it cannot
+		// mint a fresh one. A use_dpop_nonce retry would replay this assertion; for
+		// a DPoP-required org, JWT mode therefore requires the caller to supply a
+		// reusable assertion. (Non-DPoP orgs are unaffected — single request.)
 		accessToken, nonce, privateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, a.clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, "", nil)
 		if err != nil {
 			return err
@@ -666,7 +670,9 @@ func (a *JWKAuth) Authorize(method, URL string) error {
 			return err
 		}
 
-		accessToken, nonce, dpopPrivateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, "", nil)
+		// Pass the signer so a use_dpop_nonce retry can mint a fresh (single-use)
+		// client assertion rather than replaying this one.
+		accessToken, nonce, dpopPrivateKey, err := getAccessTokenForPrivateKey(a.httpClient, a.orgURL, clientAssertion, a.userAgent, a.scopes, a.maxRetries, a.maxBackoff, a.clientId, a.privateKeySigner)
 		if err != nil {
 			return err
 		}
@@ -780,118 +786,123 @@ func createClientAssertion(orgURL, clientID string, privateKeySinger jose.Signer
 	return jwtBuilder.Serialize()
 }
 
+// getAccessTokenForPrivateKey requests an access token using the private-key /
+// JWT client-credentials flow, attempting DPoP up front (DPoP-first).
+//
+// Previously this sent the first token request without a DPoP proof and only
+// retried with one after Okta rejected it with invalid_dpop_proof. For an app
+// with "Require DPoP" enabled, that proofless request is recorded as a failed
+// token grant in the org System Log on every token acquisition, and costs an
+// extra round trip. Per RFC 9449, a DPoP-capable client should attach a proof
+// proactively, so the proofless request never happens.
+//
+// The first successful response is then adapted to: if Okta issued a DPoP-bound
+// token, DPoP material is returned so the caller attaches per-request proofs; if
+// the app does not require DPoP, Okta ignores the proof and returns a Bearer
+// token, in which case the DPoP material is dropped and Bearer is used.
 func getAccessTokenForPrivateKey(httpClient *http.Client, orgURL, clientAssertion, userAgent string, scopes []string, maxRetries int32, maxBackoff int64, clientID string, signer jose.Signer) (*RequestAccessToken, string, *rsa.PrivateKey, error) {
-	query := url.Values{}
 	tokenRequestURL := orgURL + "/oauth2/v1/token"
 
-	query.Add("grant_type", "client_credentials")
-	query.Add("scope", strings.Join(scopes, " "))
-	query.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
-	query.Add("client_assertion", clientAssertion)
-
-	tokenRequest, err := http.NewRequest("POST", tokenRequestURL, strings.NewReader(query.Encode()))
-	if err != nil {
-		return nil, "", nil, err
-	}
-	tokenRequest.Header.Add("Accept", "application/json")
-	tokenRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	tokenRequest.Header.Add("User-Agent", userAgent)
-	bOff := &oktaBackoff{
-		ctx:             context.Background(),
-		maxRetries:      maxRetries,
-		backoffDuration: time.Duration(maxBackoff),
-	}
-	var tokenResponse *http.Response
-	operation := func() (*http.Response, error) {
-		resp, err := httpClient.Do(tokenRequest)
-		bOff.retryCount++
-		return resp, err
-	}
-	tokenResponse, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(bOff))
+	// One DPoP key is generated and reused across the use_dpop_nonce retry.
+	dpopKey, err := generatePrivateKey(2048)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
-	respBody, err := io.ReadAll(tokenResponse.Body)
-	origResp := io.NopCloser(bytes.NewBuffer(respBody))
-	tokenResponse.Body = origResp
-	var accessToken *RequestAccessToken
-
-	newClientAssertion, err := createClientAssertion(orgURL, clientID, signer)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	if tokenResponse.StatusCode >= 300 {
-		if strings.Contains(string(respBody), "invalid_dpop_proof") {
-			return getAccessTokenForDpopPrivateKey(tokenRequest, httpClient, orgURL, "", maxRetries, maxBackoff, newClientAssertion, strings.Join(scopes, " "), clientID, signer)
-		} else {
+	// nonce is empty on the first attempt; if the app requires DPoP, Okta
+	// responds with use_dpop_nonce and a Dpop-Nonce header, and we retry once.
+	// nonceRetried bounds that to a single retry even if the server keeps
+	// asking, and we only retry when it actually supplied a nonce.
+	nonce := ""
+	nonceRetried := false
+	for {
+		dpopJWT, err := generateDpopJWT(dpopKey, http.MethodPost, tokenRequestURL, nonce, "")
+		if err != nil {
 			return nil, "", nil, err
 		}
-	}
 
-	_, err = buildResponse(tokenResponse, nil, &accessToken)
-	if err != nil {
-		return nil, "", nil, err
-	}
-	return accessToken, "", nil, nil
-}
+		// Client assertions are single-use, so mint a fresh one per attempt when
+		// a signer is available; otherwise reuse the caller-supplied assertion.
+		assertion := clientAssertion
+		if signer != nil {
+			assertion, err = createClientAssertion(orgURL, clientID, signer)
+			if err != nil {
+				return nil, "", nil, err
+			}
+		}
 
-func getAccessTokenForDpopPrivateKey(tokenRequest *http.Request, httpClient *http.Client, orgURL, nonce string, maxRetries int32, maxBackoff int64, clientAssertion string, scopes string, clientID string, signer jose.Signer) (*RequestAccessToken, string, *rsa.PrivateKey, error) {
-	privateKey, err := generatePrivateKey(2048)
-	if err != nil {
-		return nil, "", nil, err
-	}
-	dpopJWT, err := generateDpopJWT(privateKey, http.MethodPost, fmt.Sprintf("%v%v", orgURL, "/oauth2/v1/token"), nonce, "")
-	if err != nil {
-		return nil, "", nil, err
-	}
-	newClientAssertion, err := createClientAssertion(orgURL, clientID, signer)
-	if err != nil {
-		return nil, "", nil, err
-	}
+		query := url.Values{}
+		query.Add("grant_type", "client_credentials")
+		query.Add("scope", strings.Join(scopes, " "))
+		query.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+		query.Add("client_assertion", assertion)
+		body := query.Encode()
 
-	query := url.Values{}
-	query.Add("grant_type", "client_credentials")
-	query.Add("scope", scopes)
-	query.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
-	query.Add("client_assertion", newClientAssertion)
-	tokenRequest.Body = io.NopCloser(strings.NewReader(query.Encode()))
-	tokenRequest.Header.Set("DPoP", dpopJWT)
+		tokenRequest, err := http.NewRequest("POST", tokenRequestURL, strings.NewReader(body))
+		if err != nil {
+			return nil, "", nil, err
+		}
+		tokenRequest.Header.Add("Accept", "application/json")
+		tokenRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		tokenRequest.Header.Add("User-Agent", userAgent)
+		tokenRequest.Header.Set("DPoP", dpopJWT)
 
-	bOff := &oktaBackoff{
-		ctx:             context.Background(),
-		maxRetries:      maxRetries,
-		backoffDuration: time.Duration(maxBackoff),
-	}
-	var tokenResponse *http.Response
-	operation := func() (*http.Response, error) {
-		resp, err := httpClient.Do(tokenRequest)
-		bOff.retryCount++
-		return resp, err
-	}
-	tokenResponse, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(bOff))
-	if err != nil {
-		return nil, "", nil, err
-	}
-	respBody, err := io.ReadAll(tokenResponse.Body)
-	if err != nil {
-		return nil, "", nil, err
-	}
+		bOff := &oktaBackoff{
+			ctx:             context.Background(),
+			maxRetries:      maxRetries,
+			backoffDuration: time.Duration(maxBackoff),
+		}
+		var tokenResponse *http.Response
+		operation := func() (*http.Response, error) {
+			// Rewind the body so a transport-error backoff retry re-sends it.
+			// (429/5xx come back as a response with a nil error, so backoff does not retry them here.)
+			tokenRequest.Body = io.NopCloser(strings.NewReader(body))
+			resp, err := httpClient.Do(tokenRequest)
+			bOff.retryCount++
+			return resp, err
+		}
+		tokenResponse, err = backoff.Retry(context.Background(), operation, backoff.WithBackOff(bOff))
+		if err != nil {
+			return nil, "", nil, err
+		}
 
-	if tokenResponse.StatusCode >= 300 {
-		if strings.Contains(string(respBody), "use_dpop_nonce") {
+		respBody, err := io.ReadAll(tokenResponse.Body)
+		closeErr := tokenResponse.Body.Close()
+		if err != nil {
+			return nil, "", nil, err
+		}
+		if closeErr != nil {
+			return nil, "", nil, closeErr
+		}
+		tokenResponse.Body = io.NopCloser(bytes.NewBuffer(respBody))
+
+		if tokenResponse.StatusCode >= 300 {
+			// Retry exactly once, only if Okta asked for a nonce and provided one.
 			newNonce := tokenResponse.Header.Get("Dpop-Nonce")
-			return getAccessTokenForDpopPrivateKey(tokenRequest, httpClient, orgURL, newNonce, maxRetries, maxBackoff, clientAssertion, scopes, clientID, signer)
-		} else {
+			if !nonceRetried && newNonce != "" && strings.Contains(string(respBody), "use_dpop_nonce") {
+				nonce = newNonce
+				nonceRetried = true
+				continue
+			}
+			return nil, "", nil, fmt.Errorf("token request failed (%d): %s", tokenResponse.StatusCode, strings.TrimSpace(string(respBody)))
+		}
+
+		var accessToken *RequestAccessToken
+		if _, err = buildResponse(tokenResponse, nil, &accessToken); err != nil {
 			return nil, "", nil, err
 		}
+		if accessToken == nil || accessToken.AccessToken == "" {
+			return nil, "", nil, fmt.Errorf("token response did not contain an access token")
+		}
+
+		// If the app does not require DPoP, Okta ignores the proof and returns a
+		// Bearer token; drop the DPoP material so no per-request proof is attached
+		// and no key is reused on refresh.
+		if accessToken.TokenType != "DPoP" {
+			return accessToken, "", nil, nil
+		}
+		return accessToken, nonce, dpopKey, nil
 	}
-	origResp := io.NopCloser(bytes.NewBuffer(respBody))
-	tokenResponse.Body = origResp
-	var accessToken *RequestAccessToken
-	_, err = buildResponse(tokenResponse, nil, &accessToken)
-	return accessToken, nonce, privateKey, nil
 }
 
 // NewAPIClient creates a new API client. Requires a userAgent string describing your application.

--- a/okta/client_retry_test.go
+++ b/okta/client_retry_test.go
@@ -204,25 +204,27 @@ func TestAPIClient_doWithRetries(t *testing.T) {
 		}
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/oauth2/v1/token" && authRequestCount == 0 {
-				authRequestCount++
-				w.WriteHeader(http.StatusBadRequest)
-				w.Write([]byte("invalid_dpop_proof"))
-				return
+			// DPoP-first: the SDK now attaches a proof to the first token request,
+			// so the proofless invalid_dpop_proof round trip no longer happens.
+			// Okta answers the proof-carrying request with a nonce challenge, then
+			// issues the DPoP-bound token on the retry.
+			if r.URL.Path == "/oauth2/v1/token" {
+				require.NotEmpty(t, r.Header.Get("DPoP"), "token request must carry a DPoP proof")
 			}
-			if r.URL.Path == "/oauth2/v1/token" && authRequestCount == 1 {
+			if r.URL.Path == "/oauth2/v1/token" && authRequestCount == 0 {
 				authRequestCount++
 				w.Header().Set("Dpop-Nonce", "test-nonce")
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte("use_dpop_nonce"))
 				return
 			}
-			if r.URL.Path == "/oauth2/v1/token" && authRequestCount == 2 {
+			if r.URL.Path == "/oauth2/v1/token" && authRequestCount == 1 {
+				authRequestCount++
 				w.Header().Set("Content-Type", "application/json")
 				require.NoError(t, json.NewEncoder(w).Encode(mockTokenResponse))
 				return
 			}
-			if r.URL.Path == "/oauth2/v1/token" && authRequestCount == 3 {
+			if r.URL.Path == "/oauth2/v1/token" && authRequestCount >= 2 {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte("internal_server_error"))
 				return

--- a/okta/dpop_first_test.go
+++ b/okta/dpop_first_test.go
@@ -1,0 +1,162 @@
+package okta
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAccessTokenForPrivateKeyDpopFirst verifies the DPoP-first handshake:
+// a proof is attached to the first token request (so Okta never sees, and never
+// logs, a proofless invalid_dpop_proof rejection), and the result adapts to the
+// token_type Okta returns.
+func TestGetAccessTokenForPrivateKeyDpopFirst(t *testing.T) {
+	t.Run("dpop-required app: proof sent up front, nonce challenge, no proofless request", func(t *testing.T) {
+		prooflessSeen := false
+		tokenRequests := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/oauth2/v1/token", r.URL.Path)
+			if r.Header.Get("DPoP") == "" {
+				prooflessSeen = true
+			}
+			switch tokenRequests {
+			case 0:
+				tokenRequests++
+				w.Header().Set("Dpop-Nonce", "nonce-1")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"use_dpop_nonce"}`))
+			default:
+				tokenRequests++
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(&RequestAccessToken{AccessToken: "dpop-token", TokenType: "DPoP", ExpiresIn: 3600})
+			}
+		}))
+		defer server.Close()
+
+		token, nonce, key, err := getAccessTokenForPrivateKey(server.Client(), server.URL, "assertion", "ua", []string{"okta.users.read"}, 2, 1, "", nil)
+		require.NoError(t, err)
+		require.False(t, prooflessSeen, "no token request should be sent without a DPoP proof")
+		require.Equal(t, 2, tokenRequests, "expected 2 token requests (nonce challenge + success), not the old 3")
+		require.NotNil(t, token)
+		require.Equal(t, "DPoP", token.TokenType)
+		require.Equal(t, "dpop-token", token.AccessToken)
+		require.Equal(t, "nonce-1", nonce)
+		require.NotNil(t, key, "DPoP key must be returned for per-request proofs")
+	})
+
+	t.Run("non-dpop app: bearer token returned, dpop material dropped", func(t *testing.T) {
+		tokenRequests := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/oauth2/v1/token", r.URL.Path)
+			require.NotEmpty(t, r.Header.Get("DPoP"), "a proof is still attached up front; Okta ignores it for a non-DPoP app")
+			tokenRequests++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&RequestAccessToken{AccessToken: "bearer-token", TokenType: "Bearer", ExpiresIn: 3600})
+		}))
+		defer server.Close()
+
+		token, nonce, key, err := getAccessTokenForPrivateKey(server.Client(), server.URL, "assertion", "ua", []string{"okta.users.read"}, 2, 1, "", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, tokenRequests, "a non-DPoP app needs only one token request")
+		require.NotNil(t, token)
+		require.Equal(t, "Bearer", token.TokenType)
+		require.Empty(t, nonce, "no nonce for a Bearer token")
+		require.Nil(t, key, "DPoP key must be dropped so no per-request proof is attached")
+	})
+
+	t.Run("with a signer, a fresh client assertion is minted for the nonce retry (PrivateKey/JWK modes)", func(t *testing.T) {
+		pem, err := generatePrivateKeyPem()
+		require.NoError(t, err)
+		signer, err := createKeySigner(string(pem), "kid-1")
+		require.NoError(t, err)
+
+		var assertions []string
+		count := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			assertions = append(assertions, r.FormValue("client_assertion"))
+			if count == 0 {
+				count++
+				w.Header().Set("Dpop-Nonce", "n1")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"use_dpop_nonce"}`))
+				return
+			}
+			count++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&RequestAccessToken{AccessToken: "dpop-token", TokenType: "DPoP", ExpiresIn: 3600})
+		}))
+		defer server.Close()
+
+		_, _, key, err := getAccessTokenForPrivateKey(server.Client(), server.URL, "ignored-when-signer-present", "ua", []string{"okta.users.read"}, 2, 1, "client-id", signer)
+		require.NoError(t, err)
+		require.NotNil(t, key)
+		require.Len(t, assertions, 2)
+		require.NotEmpty(t, assertions[0])
+		require.NotEqual(t, assertions[0], assertions[1], "the nonce retry must use a freshly minted (single-use) client assertion")
+	})
+
+	t.Run("without a signer (JWT mode), the caller-supplied assertion is replayed on the nonce retry", func(t *testing.T) {
+		// signer==nil is the JWTAuth path: the SDK has no way to mint a fresh
+		// assertion, so it reuses the caller-supplied one across the use_dpop_nonce
+		// retry. This locks in the documented limitation that a Require-DPoP org
+		// rejects the replayed jti; callers needing DPoP should use PrivateKeyAuth/JWKAuth.
+		var assertions []string
+		count := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+			assertions = append(assertions, r.FormValue("client_assertion"))
+			if count == 0 {
+				count++
+				w.Header().Set("Dpop-Nonce", "n1")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"use_dpop_nonce"}`))
+				return
+			}
+			count++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(&RequestAccessToken{AccessToken: "dpop-token", TokenType: "DPoP", ExpiresIn: 3600})
+		}))
+		defer server.Close()
+
+		_, _, key, err := getAccessTokenForPrivateKey(server.Client(), server.URL, "caller-assertion", "ua", []string{"okta.users.read"}, 2, 1, "", nil)
+		require.NoError(t, err)
+		require.NotNil(t, key)
+		require.Len(t, assertions, 2)
+		require.Equal(t, "caller-assertion", assertions[0])
+		require.Equal(t, assertions[0], assertions[1], "with no signer the same caller-supplied assertion is replayed on the nonce retry")
+	})
+
+	t.Run("use_dpop_nonce without a Dpop-Nonce header errors instead of looping forever", func(t *testing.T) {
+		hits := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			// Always demand a nonce but never supply one — must not loop.
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"use_dpop_nonce"}`))
+		}))
+		defer server.Close()
+
+		token, _, key, err := getAccessTokenForPrivateKey(server.Client(), server.URL, "assertion", "ua", []string{"okta.users.read"}, 2, 1, "", nil)
+		require.Error(t, err)
+		require.Nil(t, token)
+		require.Nil(t, key)
+		require.LessOrEqual(t, hits, 2, "must not retry the nonce challenge more than once")
+	})
+
+	t.Run("hard failure surfaces an error instead of looping", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_client"}`))
+		}))
+		defer server.Close()
+
+		token, _, key, err := getAccessTokenForPrivateKey(server.Client(), server.URL, "assertion", "ua", []string{"okta.users.read"}, 2, 1, "", nil)
+		require.Error(t, err)
+		require.Nil(t, token)
+		require.Nil(t, key)
+	})
+}


### PR DESCRIPTION
## Summary

The private-key / JWT client-credentials flow obtained tokens **reactively**: it sent the first `/oauth2/v1/token` request *without* a DPoP proof, let Okta reject it with `invalid_dpop_proof`, then retried with a proof. For an app with **Require DPoP** enabled, every token acquisition on this path costs an extra round trip (3 requests instead of 2) and records a **failed token grant in the org System Log**.

This PR attempts DPoP **up front**, per [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449): pre-generate one DPoP key, attach a proof to the first token request, and reuse that key across the `use_dpop_nonce` retry. The flow then **adapts to the first response**:

- Okta issues a **DPoP-bound** token → keep DPoP, return the key so per-request proofs are attached.
- App does **not** require DPoP → Okta ignores the unsolicited proof and returns a **Bearer** token → drop the DPoP material and use Bearer.

`getAccessTokenForDpopPrivateKey` is folded into the main flow and removed. **No public API change; non-DPoP apps are unaffected** (still a single token request).

The change is authored in `.generator/templates/client.mustache` (the source template) and `okta/client.go` is regenerated from it — both are committed so a future regeneration stays consistent. While in the flow I also aligned the DPoP/Bearer check to the codebase's exact `TokenType != "DPoP"` convention (the callers already use exact matching) and corrected a comment about backoff retry behavior.

**Known limitation:** in `JWTAuth` mode (caller-supplied `client_assertion`, no signer) against a Require-DPoP org, the `use_dpop_nonce` retry replays the same assertion, which Okta may reject as a reused `jti`. Callers needing DPoP should use `PrivateKeyAuth`/`JWKAuth` so the SDK can mint a fresh single-use assertion. Non-DPoP orgs and the key-based modes are unaffected.

Fixes #598

## Type of PR
- [x] Bug Fix (non-breaking fixes to existing functionality)
- [ ] New Feature (non-breaking changes that add new functionality)
- [ ] Documentation update
- [ ] Test Updates
- [ ] Other (Please describe the type)

## Test Information
- [x] My PR required test updates

Go Version: 1.24 (module minimum; locally tested with go1.26)
Os Version: macOS (darwin/arm64)
OpenAPI Spec Version: N/A — no spec change; the fix is authored in the `client.mustache` template and `okta/client.go` is regenerated from it

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does (N/A: no public API change; behavior is documented in code comments)
- [x] My code is covered by tests if required
- [x] I ran `make fmt` on my code
- [x] I did not edit any automatically generated files *(fix authored in `.generator/templates/client.mustache`; `okta/client.go` is the regenerated output committed alongside)*
